### PR TITLE
[BUGFIX] 남이 생성한 북마크에 영향 받지 않도록 수정

### DIFF
--- a/src/main/java/com/echall/platform/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/echall/platform/bookmark/repository/BookmarkRepository.java
@@ -6,5 +6,4 @@ import com.echall.platform.bookmark.domain.entity.BookmarkEntity;
 import com.echall.platform.bookmark.repository.custom.BookmarkRepositoryCustom;
 
 public interface BookmarkRepository extends JpaRepository<BookmarkEntity, Long>, BookmarkRepositoryCustom {
-	boolean existsByScriptIndexAndSentenceIndexAndWordIndex(Long scriptIndex, Long sentenceIndex, Long wordIndex);
 }

--- a/src/main/java/com/echall/platform/bookmark/repository/custom/BookmarkRepositoryCustom.java
+++ b/src/main/java/com/echall/platform/bookmark/repository/custom/BookmarkRepositoryCustom.java
@@ -1,11 +1,12 @@
 package com.echall.platform.bookmark.repository.custom;
 
-import java.util.List;
-
-import com.echall.platform.bookmark.domain.dto.BookmarkResponseDto;
+import com.echall.platform.bookmark.domain.dto.BookmarkRequestDto;
 import com.echall.platform.bookmark.domain.entity.BookmarkEntity;
+
+import java.util.List;
 
 public interface BookmarkRepositoryCustom {
 	Long deleteBookmark(Long userId, Long bookmarkId);
 	List<BookmarkEntity> getAllBookmarks(Long userId);
+	boolean isBookmarkAlreadyPresent(Long scriptIndex, BookmarkRequestDto.BookmarkCreateRequest request, Long userId);
 }

--- a/src/main/java/com/echall/platform/bookmark/service/BookmarkServiceImpl.java
+++ b/src/main/java/com/echall/platform/bookmark/service/BookmarkServiceImpl.java
@@ -76,9 +76,7 @@ public class BookmarkServiceImpl implements BookmarkService {
 			new ObjectId(contentRepository.findMongoIdByContentId(contentId))
 		).orElseThrow(() -> new CommonException(CONTENT_NOT_FOUND));
 
-		if (bookmarkRepository.existsByScriptIndexAndSentenceIndexAndWordIndex(
-			contentId, bookmarkRequestDto.sentenceIndex(), bookmarkRequestDto.wordIndex()
-		)) {
+		if (bookmarkRepository.isBookmarkAlreadyPresent(contentId, bookmarkRequestDto, user.getId())) {
 			throw new CommonException(BOOKMARK_ALREADY_EXISTS);
 		}
 


### PR DESCRIPTION
### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 리팩토링
- [ ] 스타일 수정
- [ ] 테스트 코드 추가
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 개발 환경 세팅

### 변경 사항
- 북마크를 생성할 때, 모든 유저에 대해 해당 북마크가 존재하는지에 대한 쿼리를 날리고 있는 것을 생성하려는 유저의 북마크에 해당 북마크가 존재하는지에 대한 쿼리를 날리도록 수정

#### 스크린샷 / 데모 링크
- 수정된 쿼리
![image](https://github.com/user-attachments/assets/61e795a3-41b0-4802-9f5a-c38feb2a4ee5)


### 참고 사항
- 관련 이슈 번호: #234 
- 레포지토리 메서드에서 더 좋은 네이밍이 있으시면 추천 받습니다 ㅎㅎ..


### 셀프 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [x] 새로운 테스트를 추가했거나 기존 테스트를 통과하는지 확인
- [x] 코드 스타일 가이드에 맞게 포맷팅했는지 확인
- [ ] 관련 문서를 업데이트했는지 확인
