### PR TITLE
[BUGFIX] OAuth2 인증 과정에서 필요한 쿠키 유효 시간 10초에서 3분으로 확장

### DIFF
--- a/src/main/java/com/echall/platform/oauth2/repository/OAuth2AuthorizationRequestBasedOnCookieRepository.java
+++ b/src/main/java/com/echall/platform/oauth2/repository/OAuth2AuthorizationRequestBasedOnCookieRepository.java
@@ -16,12 +16,10 @@ public class OAuth2AuthorizationRequestBasedOnCookieRepository
 	implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
 	private final CookieUtil cookieUtil;
 
-	private static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE = "oauth2_authorization_request";
-
 	@Override
 	public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
 
-		Cookie cookie = WebUtils.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE);
+		Cookie cookie = WebUtils.getCookie(request, CookieUtil.OAUTH2_AUTHORIZATION_REQUEST_NAME);
 		if(cookie == null) {
 			return null;
 		}
@@ -34,7 +32,7 @@ public class OAuth2AuthorizationRequestBasedOnCookieRepository
 		HttpServletResponse response) {
 
 		if(authorizationRequest == null) {
-			removeCookies(request,response);
+			removeCookies(request, response);
 			return;
 		}
 

--- a/src/main/java/com/echall/platform/util/CookieUtil.java
+++ b/src/main/java/com/echall/platform/util/CookieUtil.java
@@ -26,8 +26,8 @@ public class CookieUtil {
 	public static final String RETURN_URL_REQUEST_PARAMETER = "returnUrl";
 	public static final Duration ACCESS_TOKEN_COOKIE_EXPIRE = Duration.ofDays(1);
 	public static final Duration REFRESH_TOKEN_COOKIE_EXPIRE = Duration.ofDays(7);
-	public static final Duration OAUTH2_AUTHORIZATION_REQUEST_COOKIE_EXPIRE = Duration.ofSeconds(10);
-	public static final Duration RETURN_URL_NAME_COOKIE_EXPIRE = Duration.ofSeconds(10);
+	public static final Duration OAUTH2_AUTHORIZATION_REQUEST_COOKIE_EXPIRE = Duration.ofMinutes(3);
+	public static final Duration RETURN_URL_NAME_COOKIE_EXPIRE = Duration.ofMinutes(3);
 
 	@Value("${spring.profiles.active}")
 	private String activeProfile;


### PR DESCRIPTION
### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 리팩토링
- [ ] 스타일 수정
- [ ] 테스트 코드 추가
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 개발 환경 세팅

### 변경 사항
- OAuth2 소셜 로그인할 때 필요한 쿠키 유효시간 10초에서 3분으로 확장
- 그 외에 자잘한 코드 수정(로직은 동일)

#### 스크린샷 / 데모 링크
- 스크린샷이나 데모 링크를 첨부하여 변경 내용을 시각적으로 보여주세요.

### 참고 사항
- 관련 이슈 번호: #235 
- OAuth2 소셜 로그인할 때 인증에 사용하는 쿠키 유효시간이 10초라서 인증과정이 길어지면 쿠키가 사라져 정상적인 로그인에 실패하는 상황이 발생하여 쿠키 유효시간을 늘렸습니다.


### 셀프 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [x] 새로운 테스트를 추가했거나 기존 테스트를 통과하는지 확인
- [x] 코드 스타일 가이드에 맞게 포맷팅했는지 확인
- [ ] 관련 문서를 업데이트했는지 확인
