### PR TITLE
[REFACTOR] 프론트 요청 : wordIndex 삭제

### DIFF
--- a/user-api/src/main/java/com/biengual/userapi/bookmark/domain/BookmarkCommand.java
+++ b/user-api/src/main/java/com/biengual/userapi/bookmark/domain/BookmarkCommand.java
@@ -18,14 +18,12 @@ public class BookmarkCommand {
 		Long userId,
 		Long contentId,
 		Long sentenceIndex,
-		Long wordIndex,
 		String description
 	) {
 		public BookmarkEntity toEntity(String detail, Double startTime) {
 			return BookmarkEntity.builder()
 				.scriptIndex(this.contentId)
 				.sentenceIndex(this.sentenceIndex)
-				.wordIndex(this.wordIndex)
 				.description(this.description)
 				.detail(detail)
 				.startTimeInSecond(startTime)

--- a/user-api/src/main/java/com/biengual/userapi/bookmark/domain/BookmarkEntity.java
+++ b/user-api/src/main/java/com/biengual/userapi/bookmark/domain/BookmarkEntity.java
@@ -32,9 +32,6 @@ public class BookmarkEntity extends BaseEntity {
 	@Column(columnDefinition = "bigint")
 	private Long sentenceIndex;
 
-	@Column(columnDefinition = "bigint")
-	private Long wordIndex;
-
 	@Column(columnDefinition = "varchar(512)")
 	private String detail;
 
@@ -46,12 +43,11 @@ public class BookmarkEntity extends BaseEntity {
 
 	@Builder
 	public BookmarkEntity(
-		@NotNull Long scriptIndex, Long sentenceIndex, Long wordIndex,
+		@NotNull Long scriptIndex, Long sentenceIndex,
 		String detail, String description, Double startTimeInSecond
 	) {
 		this.scriptIndex = scriptIndex;
 		this.sentenceIndex = sentenceIndex;
-		this.wordIndex = wordIndex;
 		this.detail = detail;
 		this.description = description;
 		this.startTimeInSecond = startTimeInSecond;

--- a/user-api/src/main/java/com/biengual/userapi/bookmark/domain/BookmarkInfo.java
+++ b/user-api/src/main/java/com/biengual/userapi/bookmark/domain/BookmarkInfo.java
@@ -13,7 +13,6 @@ public class BookmarkInfo {
 	public record Position(
 		Long bookmarkId,
 		Long sentenceIndex,
-		Long wordIndex,
 		String description,
 		Double startTimeInSecond
 	) {

--- a/user-api/src/main/java/com/biengual/userapi/bookmark/domain/BookmarkRepositoryImpl.java
+++ b/user-api/src/main/java/com/biengual/userapi/bookmark/domain/BookmarkRepositoryImpl.java
@@ -52,14 +52,8 @@ public class BookmarkRepositoryImpl extends QuerydslRepositorySupport implements
 	}
 
 	private BooleanExpression bookmarkBooleanExpression(BookmarkCommand.Create command) {
-		BooleanExpression wordIndexExpression = bookmarkEntity.wordIndex.isNull();
-		if (command.wordIndex() != null) {
-			wordIndexExpression = bookmarkEntity.wordIndex.eq(command.wordIndex());
-		}
-
 		return userEntity.id.eq(command.userId())
 			.and(bookmarkEntity.scriptIndex.eq(command.contentId()))
-			.and(bookmarkEntity.sentenceIndex.eq(command.sentenceIndex()))
-			.and(wordIndexExpression);
+			.and(bookmarkEntity.sentenceIndex.eq(command.sentenceIndex()));
 	}
 }

--- a/user-api/src/main/java/com/biengual/userapi/bookmark/infrastructure/BookmarkStoreImpl.java
+++ b/user-api/src/main/java/com/biengual/userapi/bookmark/infrastructure/BookmarkStoreImpl.java
@@ -76,11 +76,9 @@ public class BookmarkStoreImpl implements BookmarkStore {
 	// Internal Methods ------------------------------------------------------------------------------------------------
 
 	private String extractDetail(BookmarkCommand.Create command, ContentDocument content) {
-		return truncate(command.wordIndex() == null ?
-				content.getScripts().get(Math.toIntExact(command.sentenceIndex())).getEnScript() :
-				content.getScripts().get(Math.toIntExact(command.sentenceIndex())).getEnScript()
-					.split(" ")[Math.toIntExact(command.wordIndex())],
-			255);
+		return truncate(
+			content.getScripts().get(Math.toIntExact(command.sentenceIndex())).getEnScript(), 255
+		);
 	}
 
 	private Double extractStartTime(BookmarkCommand.Create command, ContentDocument content) {

--- a/user-api/src/main/java/com/biengual/userapi/bookmark/presentation/BookmarkRequestDto.java
+++ b/user-api/src/main/java/com/biengual/userapi/bookmark/presentation/BookmarkRequestDto.java
@@ -7,7 +7,6 @@ public class BookmarkRequestDto {
 	public record CreateReq(
 		@NotNull
 		Long sentenceIndex,
-		Long wordIndex,
 		String description
 	) {
 	}
@@ -18,5 +17,4 @@ public class BookmarkRequestDto {
 		String description
 	) {
 	}
-
 }

--- a/user-api/src/main/java/com/biengual/userapi/bookmark/presentation/BookmarkResponseDto.java
+++ b/user-api/src/main/java/com/biengual/userapi/bookmark/presentation/BookmarkResponseDto.java
@@ -12,7 +12,6 @@ public class BookmarkResponseDto {
 	public record ContentList(
 		Long bookmarkId,
 		Long sentenceIndex,
-		Long wordIndex,
 		String description,
 		@JsonInclude(JsonInclude.Include.NON_NULL)
 		Double startTimeInSecond
@@ -42,5 +41,4 @@ public class BookmarkResponseDto {
 		List<MyList> bookmarkMyList
 	) {
 	}
-
 }


### PR DESCRIPTION
### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 리팩토링
- [ ] 스타일 수정
- [ ] 테스트 코드 추가
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 개발 환경 세팅

### 변경 사항
- wordIndex 필요 없다는 프론트 요청에 따라 삭제

### 참고 사항
- 관련 이슈 번호: #264 
- 이 PR이 머지되면 아래 두 명령어로 각 DB 에서 단어 북마크 삭제 예정
    - `DELETE FROM echall_local_db WHERE wordIndex IS NOT NULL;`
    - `ALTER TABLE echall_local_db DROP COLUMN wordIndex ;`

### 셀프 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [x] 새로운 테스트를 추가했거나 기존 테스트를 통과하는지 확인
- [x] 코드 스타일 가이드에 맞게 포맷팅했는지 확인
- [x] 관련 문서를 업데이트했는지 확인
