### PR TITLE
[REFACTOR] content-api querydsl 수정 및 일부 api 수정

### DIFF
--- a/user-api/src/main/java/com/biengual/userapi/bookmark/infrastructure/BookmarkReaderImpl.java
+++ b/user-api/src/main/java/com/biengual/userapi/bookmark/infrastructure/BookmarkReaderImpl.java
@@ -9,7 +9,7 @@ import com.biengual.userapi.bookmark.domain.BookmarkEntity;
 import com.biengual.userapi.bookmark.domain.BookmarkInfo;
 import com.biengual.userapi.bookmark.domain.BookmarkReader;
 import com.biengual.userapi.bookmark.presentation.BookmarkDtoMapper;
-import com.biengual.userapi.content.domain.ContentRepository;
+import com.biengual.userapi.content.domain.ContentCustomRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class BookmarkReaderImpl implements BookmarkReader {
 	private final BookmarkCustomRepository bookmarkCustomRepository;
-	private final ContentRepository contentRepository;
+	private final ContentCustomRepository contentCustomRepository;
 	private final BookmarkDtoMapper bookmarkDtoMapper;
 
 	@Override
@@ -34,8 +34,8 @@ public class BookmarkReaderImpl implements BookmarkReader {
 		return bookmarks.stream()
 			.map(bookmark -> bookmarkDtoMapper.buildMyList(
 				bookmark,
-				contentRepository.findContentTypeById(bookmark.getScriptIndex()),
-				contentRepository.findTitleById(bookmark.getScriptIndex())
+				contentCustomRepository.findContentTypeById(bookmark.getScriptIndex()),
+				contentCustomRepository.findTitleById(bookmark.getScriptIndex())
 			)).toList();
 	}
 

--- a/user-api/src/main/java/com/biengual/userapi/bookmark/infrastructure/BookmarkStoreImpl.java
+++ b/user-api/src/main/java/com/biengual/userapi/bookmark/infrastructure/BookmarkStoreImpl.java
@@ -13,10 +13,11 @@ import com.biengual.userapi.bookmark.domain.BookmarkInfo;
 import com.biengual.userapi.bookmark.domain.BookmarkRepository;
 import com.biengual.userapi.bookmark.domain.BookmarkStore;
 import com.biengual.userapi.bookmark.presentation.BookmarkDtoMapper;
+import com.biengual.userapi.content.domain.ContentCustomRepository;
 import com.biengual.userapi.content.domain.ContentDocument;
-import com.biengual.userapi.content.domain.ContentType;
 import com.biengual.userapi.content.domain.ContentRepository;
 import com.biengual.userapi.content.domain.ContentScriptRepository;
+import com.biengual.userapi.content.domain.ContentType;
 import com.biengual.userapi.message.error.exception.CommonException;
 import com.biengual.userapi.script.domain.entity.YoutubeScript;
 
@@ -28,6 +29,7 @@ public class BookmarkStoreImpl implements BookmarkStore {
 	private final BookmarkRepository bookmarkRepository;
 	private final BookmarkCustomRepository bookmarkCustomRepository;
 	private final ContentRepository contentRepository;
+	private final ContentCustomRepository contentCustomRepository;
 	private final ContentScriptRepository contentScriptRepository;
 	private final BookmarkDtoMapper bookmarkDtoMapper;
 
@@ -39,7 +41,7 @@ public class BookmarkStoreImpl implements BookmarkStore {
 	@Override
 	public void saveBookmark(BookmarkCommand.Create command) {
 		ContentDocument content = contentScriptRepository.findContentDocumentById(
-			new ObjectId(contentRepository.findMongoIdByContentId(command.contentId()))
+			new ObjectId(contentCustomRepository.findMongoIdByContentId(command.contentId()))
 		).orElseThrow(() -> new CommonException(CONTENT_NOT_FOUND));
 
 		BookmarkEntity bookmark
@@ -68,7 +70,7 @@ public class BookmarkStoreImpl implements BookmarkStore {
 	}
 
 	private Double extractStartTime(BookmarkCommand.Create command, ContentDocument content) {
-		if (contentRepository.findContentTypeById(command.contentId()).equals(ContentType.READING)) {
+		if (contentCustomRepository.findContentTypeById(command.contentId()).equals(ContentType.READING)) {
 			return null;
 		}
 

--- a/user-api/src/main/java/com/biengual/userapi/content/application/ContentFacade.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/application/ContentFacade.java
@@ -18,11 +18,7 @@ public class ContentFacade {
 		contentService.createContent(createContent);
 	}
 
-	public void modifyContent(ContentCommand.Modify command) {
-		contentService.updateContent(command);
-	}
-
-	public void deactivateContent(Long id) {
-		contentService.deactivateContent(id);
+	public void modifyContent(Long id) {
+		contentService.modifyContent(id);
 	}
 }

--- a/user-api/src/main/java/com/biengual/userapi/content/application/ContentFacade.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/application/ContentFacade.java
@@ -18,7 +18,7 @@ public class ContentFacade {
 		contentService.createContent(createContent);
 	}
 
-	public void modifyContent(Long id) {
-		contentService.modifyContent(id);
+	public void modifyContentStatus(Long contentId) {
+		contentService.modifyContentStatus(contentId);
 	}
 }

--- a/user-api/src/main/java/com/biengual/userapi/content/application/ContentServiceImpl.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/application/ContentServiceImpl.java
@@ -86,8 +86,8 @@ public class ContentServiceImpl implements ContentService {
 
 	@Override
 	@Transactional
-	public void modifyContent(Long contentId) {
-		contentStore.modifyContent(contentId);
+	public void modifyContentStatus(Long contentId) {
+		contentStore.modifyContentStatus(contentId);
 	}
 
 	@Override

--- a/user-api/src/main/java/com/biengual/userapi/content/application/ContentServiceImpl.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/application/ContentServiceImpl.java
@@ -71,12 +71,6 @@ public class ContentServiceImpl implements ContentService {
 	}
 
 	@Override
-	@Transactional
-	public void updateContent(ContentCommand.Modify command) {
-		contentStore.updateContent(command);
-	}
-
-	@Override
 	@Transactional(readOnly = true)
 	public List<ContentResponseDto.PreviewRes> findPreviewContents(
 		ContentType contentType, String sortBy, int num
@@ -92,8 +86,8 @@ public class ContentServiceImpl implements ContentService {
 
 	@Override
 	@Transactional
-	public void deactivateContent(Long contentId) {
-		contentStore.deactivateContent(contentId);
+	public void modifyContent(Long contentId) {
+		contentStore.modifyContent(contentId);
 	}
 
 	@Override

--- a/user-api/src/main/java/com/biengual/userapi/content/domain/ContentCommand.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/domain/ContentCommand.java
@@ -52,14 +52,4 @@ public class ContentCommand {
 		}
 	}
 
-	@Builder
-	public record Modify(
-		Long id,
-		String url,
-		String title,
-		List<Script> script,
-		ContentStatus contentStatus
-	) {
-	}
-
 }

--- a/user-api/src/main/java/com/biengual/userapi/content/domain/ContentCustomRepository.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/domain/ContentCustomRepository.java
@@ -1,0 +1,53 @@
+package com.biengual.userapi.content.domain;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ContentCustomRepository {
+	private final JPAQueryFactory queryFactory;
+
+	public ContentType findContentTypeById(Long contentId) {
+		QContentEntity contentEntity = QContentEntity.contentEntity;
+
+		return queryFactory
+			.select(contentEntity.contentType)
+			.from(contentEntity)
+			.where(contentEntity.id.eq(contentId))
+			.fetchFirst();
+
+	}
+
+	public String findTitleById(Long contentId) {
+		QContentEntity contentEntity = QContentEntity.contentEntity;
+
+		return queryFactory
+			.select(contentEntity.title)
+			.from(contentEntity)
+			.where(contentEntity.contentStatus.eq(ContentStatus.ACTIVATED).and(contentEntity.id.eq(contentId)))
+			.fetchFirst();
+	}
+
+	public String findMongoIdByContentId(Long contentId) {
+		QContentEntity contentEntity = QContentEntity.contentEntity;
+
+		return queryFactory
+			.select(contentEntity.mongoContentId)
+			.from(contentEntity)
+			.where(contentEntity.contentStatus.eq(ContentStatus.ACTIVATED).and(contentEntity.id.eq(contentId)))
+			.fetchOne();
+	}
+
+	public boolean existsByUrl(String url) {
+		QContentEntity contentEntity = QContentEntity.contentEntity;
+
+		return queryFactory
+			.from(contentEntity)
+			.where(contentEntity.url.eq(url))
+			.fetchFirst() != null;
+	}
+}

--- a/user-api/src/main/java/com/biengual/userapi/content/domain/ContentDocument.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/domain/ContentDocument.java
@@ -30,10 +30,6 @@ public class ContentDocument extends MongoBaseDocument {
 		this.questionIds = new ArrayList<>();
 	}
 
-	public void updateScript(List<Script> scriptList) {
-		this.scripts = scriptList;
-	}
-
 	public void updateQuestionIds(List<String> questionIds) {
 		this.questionIds.addAll(questionIds);
 	}

--- a/user-api/src/main/java/com/biengual/userapi/content/domain/ContentEntity.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/domain/ContentEntity.java
@@ -86,18 +86,6 @@ public class ContentEntity extends BaseEntity {
 		this.category = category;
 	}
 
-	public void update(ContentCommand.Modify command) {
-		this.url = command.url();
-		this.title = command.title();
-		this.contentStatus = command.contentStatus() == null ? ContentStatus.ACTIVATED : command.contentStatus();
-		this.preScripts = truncate(
-			command.script().subList(0, Math.min(command.script().size(), 5))
-				.stream()
-				.map(Script::getEnScript)
-				.toList().toString()
-			, 255);
-	}
-
 	public void updateStatus(ContentStatus contentStatus) {
 		this.contentStatus = contentStatus == null ? ContentStatus.ACTIVATED : contentStatus;
 	}

--- a/user-api/src/main/java/com/biengual/userapi/content/domain/ContentRepositoryCustom.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/domain/ContentRepositoryCustom.java
@@ -22,13 +22,6 @@ public interface ContentRepositoryCustom {
 
 	Page<ContentEntity> findAllByContentTypeAndCategory(ContentType contentType, Pageable pageable, Long categoryId);
 
-	String findTitleById(Long contentId);
-
-	String findMongoIdByContentId(Long contentId);
-
 	List<ContentResponseDto.GetByScrapCount> contentByScrapCount(int num);
 
-	ContentType findContentTypeById(Long scriptIndex);
-
-	boolean existsByUrl(String url);
 }

--- a/user-api/src/main/java/com/biengual/userapi/content/domain/ContentRepositoryImpl.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/domain/ContentRepositoryImpl.java
@@ -136,23 +136,6 @@ public class ContentRepositoryImpl extends QuerydslRepositorySupport implements 
 	}
 
 	@Override
-	public String findTitleById(Long contentId) {
-
-		return from(contentEntity)
-			.select(contentEntity.title)
-			.where(contentEntity.contentStatus.eq(ContentStatus.ACTIVATED).and(contentEntity.id.eq(contentId)))
-			.fetchFirst();
-	}
-
-	@Override
-	public String findMongoIdByContentId(Long contentId) {
-		return from(contentEntity)
-			.select(contentEntity.mongoContentId)
-			.where(contentEntity.contentStatus.eq(ContentStatus.ACTIVATED).and(contentEntity.id.eq(contentId)))
-			.fetchOne();
-	}
-
-	@Override
 	public List<ContentResponseDto.GetByScrapCount> contentByScrapCount(int num) {
 		List<Tuple> tuples = from(scrapEntity)
 			.select(scrapEntity.content.id, scrapEntity.count())
@@ -183,22 +166,6 @@ public class ContentRepositoryImpl extends QuerydslRepositorySupport implements 
 			}).sorted(Comparator.comparing(ContentResponseDto.GetByScrapCount::countScrap).reversed())
 			.toList();
 
-	}
-
-	@Override
-	public ContentType findContentTypeById(Long contentId) {
-		return from(contentEntity)
-			.select(contentEntity.contentType)
-			.where(contentEntity.id.eq(contentId))
-			.fetchFirst();
-
-	}
-
-	@Override
-	public boolean existsByUrl(String url) {
-		return from(contentEntity)
-			.where(contentEntity.url.eq(url))
-			.fetchFirst() != null;
 	}
 
 	private List<String> splitIntoWords(String words) {

--- a/user-api/src/main/java/com/biengual/userapi/content/domain/ContentService.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/domain/ContentService.java
@@ -21,9 +21,7 @@ public interface ContentService {
 
 	void createContent(ContentCommand.Create command);
 
-	void updateContent(ContentCommand.Modify command);
-
-	void deactivateContent(Long id);
+	void modifyContent(Long id);
 
 	List<ContentResponseDto.PreviewRes> findPreviewContents(
 		ContentType contentType, String sortBy, int num

--- a/user-api/src/main/java/com/biengual/userapi/content/domain/ContentService.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/domain/ContentService.java
@@ -21,7 +21,7 @@ public interface ContentService {
 
 	void createContent(ContentCommand.Create command);
 
-	void modifyContent(Long id);
+	void modifyContentStatus(Long contentId);
 
 	List<ContentResponseDto.PreviewRes> findPreviewContents(
 		ContentType contentType, String sortBy, int num

--- a/user-api/src/main/java/com/biengual/userapi/content/domain/ContentStore.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/domain/ContentStore.java
@@ -3,5 +3,5 @@ package com.biengual.userapi.content.domain;
 public interface ContentStore {
 	void createContent(ContentCommand.Create command);
 
-	void modifyContent(Long id);
+	void modifyContentStatus(Long contentId);
 }

--- a/user-api/src/main/java/com/biengual/userapi/content/domain/ContentStore.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/domain/ContentStore.java
@@ -3,7 +3,5 @@ package com.biengual.userapi.content.domain;
 public interface ContentStore {
 	void createContent(ContentCommand.Create command);
 
-	void updateContent(ContentCommand.Modify command);
-
-	void deactivateContent(Long id);
+	void modifyContent(Long id);
 }

--- a/user-api/src/main/java/com/biengual/userapi/content/infrastructure/ContentStoreImpl.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/infrastructure/ContentStoreImpl.java
@@ -36,7 +36,7 @@ public class ContentStoreImpl implements ContentStore {
 	}
 
 	@Override
-	public void modifyContent(Long contentId) {
+	public void modifyContentStatus(Long contentId) {
 		ContentEntity content = contentRepository.findById(contentId)
 			.orElseThrow(() -> new CommonException(CONTENT_NOT_FOUND));
 		content.updateStatus(

--- a/user-api/src/main/java/com/biengual/userapi/content/infrastructure/ContentStoreImpl.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/infrastructure/ContentStoreImpl.java
@@ -3,8 +3,6 @@ package com.biengual.userapi.content.infrastructure;
 import static com.biengual.userapi.message.error.code.CategoryErrorCode.*;
 import static com.biengual.userapi.message.error.code.ContentErrorCode.*;
 
-import org.bson.types.ObjectId;
-
 import com.biengual.userapi.annotation.DataProvider;
 import com.biengual.userapi.category.domain.CategoryEntity;
 import com.biengual.userapi.category.repository.CategoryRepository;
@@ -38,25 +36,12 @@ public class ContentStoreImpl implements ContentStore {
 	}
 
 	@Override
-	public void updateContent(ContentCommand.Modify command) {
-		ContentEntity content = contentRepository.findById(command.id())
-			.orElseThrow(() -> new CommonException(CONTENT_NOT_FOUND));
-		content.update(command);
-		contentRepository.save(content);
-
-		ContentDocument contentDocument
-			= contentScriptRepository.findContentDocumentById(new ObjectId(content.getMongoContentId()))
-			.orElseThrow(() -> new CommonException(CONTENT_NOT_FOUND));
-		contentDocument.updateScript(command.script());
-		contentScriptRepository.save(contentDocument);
-	}
-
-	@Override
-	public void deactivateContent(Long contentId) {
+	public void modifyContent(Long contentId) {
 		ContentEntity content = contentRepository.findById(contentId)
 			.orElseThrow(() -> new CommonException(CONTENT_NOT_FOUND));
-
-		content.updateStatus(ContentStatus.DEACTIVATED);
+		content.updateStatus(
+			content.getContentStatus() == ContentStatus.ACTIVATED ? ContentStatus.DEACTIVATED : ContentStatus.ACTIVATED
+		);
 		contentRepository.save(content);
 	}
 

--- a/user-api/src/main/java/com/biengual/userapi/content/presentation/ContentApiController.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/presentation/ContentApiController.java
@@ -60,12 +60,12 @@ public class ContentApiController {
 	}
 
 	/**
-	 * 컨텐츠 수정
+	 * 컨텐츠 활성화, 비활성화
 	 */
-	@PutMapping("/modify/{contentId}")
-	@Operation(summary = "어드민 - 컨텐츠 수정", description = "어드민 회원이 컨텐츠를 수정합니다.")
+	@PutMapping("/toggle-active/{contentId}")
+	@Operation(summary = "어드민 - 컨텐츠 상태 수정", description = "어드민 회원이 컨텐츠 상태를 변경합니다.")
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "컨텐츠 수정 성공",
+		@ApiResponse(responseCode = "200", description = "컨텐츠 상태 변경 성공",
 			content = {
 				@Content(mediaType = "application/json", schema = @Schema(implementation = SwaggerVoidReturn.class))}
 		),
@@ -74,35 +74,10 @@ public class ContentApiController {
 	})
 	public ResponseEntity<Object> modifyContent(
 		@PathVariable
-		Long contentId,
-		@RequestBody
-		ContentRequestDto.UpdateReq request
-	) {
-		ContentCommand.Modify command = contentDtoMapper.doModify(contentId, request);
-		contentFacade.modifyContent(command);
-
-		return ResponseEntityFactory.toResponseEntity(CONTENT_MODIFY_SUCCESS);
-	}
-
-	/**
-	 * 컨텐츠 비활성화
-	 */
-	@PutMapping("/deactivate/{contentId}")
-	@Operation(summary = "어드민 - 컨텐츠 비활성화", description = "어드민 회원이 컨텐츠를 비활성화합니다.")
-	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "컨텐츠 비활성화 성공",
-			content = {
-				@Content(mediaType = "application/json", schema = @Schema(implementation = SwaggerVoidReturn.class))}
-		),
-		@ApiResponse(responseCode = "404", description = "컨텐츠 조회 실패", content = @Content(mediaType = "application/json")),
-		@ApiResponse(responseCode = "500", description = "서버 에러", content = @Content(mediaType = "application/json"))
-	})
-	public ResponseEntity<Object> deactivateContent(
-		@PathVariable
 		Long contentId
 	) {
-		contentFacade.deactivateContent(contentId);
+		contentFacade.modifyContent(contentId);
 
-		return ResponseEntityFactory.toResponseEntity(CONTENT_DEACTIVATE_SUCCESS);
+		return ResponseEntityFactory.toResponseEntity(CONTENT_MODIFY_SUCCESS);
 	}
 }

--- a/user-api/src/main/java/com/biengual/userapi/content/presentation/ContentApiController.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/presentation/ContentApiController.java
@@ -72,11 +72,11 @@ public class ContentApiController {
 		@ApiResponse(responseCode = "404", description = "컨텐츠 조회 실패", content = @Content(mediaType = "application/json")),
 		@ApiResponse(responseCode = "500", description = "서버 에러", content = @Content(mediaType = "application/json"))
 	})
-	public ResponseEntity<Object> modifyContent(
+	public ResponseEntity<Object> modifyContentStatus(
 		@PathVariable
 		Long contentId
 	) {
-		contentFacade.modifyContent(contentId);
+		contentFacade.modifyContentStatus(contentId);
 
 		return ResponseEntityFactory.toResponseEntity(CONTENT_MODIFY_SUCCESS);
 	}

--- a/user-api/src/main/java/com/biengual/userapi/content/presentation/ContentDtoMapper.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/presentation/ContentDtoMapper.java
@@ -25,9 +25,6 @@ public interface ContentDtoMapper {
 	// Command <- Request
 	ContentCommand.CrawlingContent doCrawlingContent(ContentRequestDto.CreateReq request);
 
-	@Mapping(target = "id", source = "contentId")
-	ContentCommand.Modify doModify(Long contentId, ContentRequestDto.UpdateReq request);
-
 	// Response <- Info
 	// Entity <-> Info, Info <-> Info
 

--- a/user-api/src/main/java/com/biengual/userapi/content/presentation/ContentRequestDto.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/presentation/ContentRequestDto.java
@@ -14,15 +14,6 @@ public class ContentRequestDto {
 	) {
 	}
 
-	public record UpdateReq(
-		String url,
-		String title,
-		List<Script> script,
-		ContentStatus contentStatus
-	) {
-
-	}
-
 	public record SearchReq(
 		String searchWords
 	) {

--- a/user-api/src/main/java/com/biengual/userapi/crawling/infrastructure/CrawlingStoreImpl.java
+++ b/user-api/src/main/java/com/biengual/userapi/crawling/infrastructure/CrawlingStoreImpl.java
@@ -30,7 +30,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
 import com.biengual.userapi.content.domain.ContentCommand;
-import com.biengual.userapi.content.domain.ContentRepository;
+import com.biengual.userapi.content.domain.ContentCustomRepository;
 import com.biengual.userapi.content.domain.ContentType;
 import com.biengual.userapi.crawling.application.TranslateService;
 import com.biengual.userapi.crawling.domain.CrawlingStore;
@@ -52,7 +52,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class CrawlingStoreImpl implements CrawlingStore {
 	private final TranslateService translateService;
-	private final ContentRepository contentRepository;
+	private final ContentCustomRepository contentCustomRepository;
 
 	@Value("${YOUTUBE_API_KEY}")
 	private String YOUTUBE_API_KEY;
@@ -109,6 +109,10 @@ public class CrawlingStoreImpl implements CrawlingStore {
 	@Override
 	public ContentCommand.Create getCNNDetail(ContentCommand.CrawlingContent command) {
 		CrawlingResponseDto.ContentDetailRes response = fetchArticle(command.url());
+
+		// Check Already Stored In DB
+		verifyCrawling(command.url());
+
 		return ContentCommand.Create.builder()
 			.url(response.url())
 			.title(response.title())
@@ -406,7 +410,7 @@ public class CrawlingStoreImpl implements CrawlingStore {
 	// COMMON
 
 	private void verifyCrawling(String url) {
-		if (contentRepository.existsByUrl(url)) {
+		if (contentCustomRepository.existsByUrl(url)) {
 			throw new CommonException(CRAWLING_ALREADY_DONE);
 		}
 	}

--- a/user-api/src/main/java/com/biengual/userapi/message/response/ContentResponseCode.java
+++ b/user-api/src/main/java/com/biengual/userapi/message/response/ContentResponseCode.java
@@ -11,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 public enum ContentResponseCode implements ResponseCode {
 	CONTENT_CREATE_SUCCESS(HttpStatus.CREATED, ContentServiceStatus.CONTENT_CREATE_SUCCESS, "컨텐츠 생성 성공"),
 	CONTENT_VIEW_SUCCESS(HttpStatus.OK, ContentServiceStatus.CONTENT_VIEW_SUCCESS, "컨텐츠 조회 성공"),
-	CONTENT_MODIFY_SUCCESS(HttpStatus.OK, ContentServiceStatus.CONTENT_MODIFY_SUCCESS, "컨텐츠 수정 성공"),
+	CONTENT_MODIFY_SUCCESS(HttpStatus.OK, ContentServiceStatus.CONTENT_MODIFY_SUCCESS, "컨텐츠 상태 변경 성공"),
 	CONTENT_DEACTIVATE_SUCCESS(HttpStatus.OK, ContentServiceStatus.CONTENT_DEACTIVATE_SUCCESS, "컨텐츠 비활성화 성공")
 	;
 


### PR DESCRIPTION
### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 리팩토링
- [ ] 스타일 수정
- [ ] 테스트 코드 추가
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 개발 환경 세팅

### 변경 사항
- content api 관련 querydsl을 JPAQueryFactory를 활용한 ContentCustomRepository로 수정
- content api의 modify 삭제
- content api의 deactivate 를 toggle-active 로 수정하고 요청마다 ACTIVATED <-> DEACTIVATED 할 수 있도록 수정
- 리턴 상태 메세지 수정

### 참고 사항
- 관련 이슈 번호: #282 

### 셀프 체크리스트
- [ ] 코드가 정상적으로 동작하는지 확인
- [ ] 새로운 테스트를 추가했거나 기존 테스트를 통과하는지 확인
- [ ] 코드 스타일 가이드에 맞게 포맷팅했는지 확인
- [ ] 관련 문서를 업데이트했는지 확인
