### PR TITLE
[BUGFIX] 컨텐츠 디테일 조회시 bookmarkId도 추가로 보내도록 수정

### DIFF
--- a/user-api/src/main/java/com/biengual/userapi/bookmark/domain/BookmarkCustomRepository.java
+++ b/user-api/src/main/java/com/biengual/userapi/bookmark/domain/BookmarkCustomRepository.java
@@ -19,8 +19,8 @@ import lombok.RequiredArgsConstructor;
 public class BookmarkCustomRepository {
     private final JPAQueryFactory queryFactory;
 
-    public void deleteBookmark(BookmarkCommand.Delete command) {
-        queryFactory.delete(bookmarkEntity)
+    public long deleteBookmark(BookmarkCommand.Delete command) {
+        return queryFactory.delete(bookmarkEntity)
             .where(bookmarkEntity.userId.eq(command.userId()))
             .where(bookmarkEntity.id.eq(command.bookmarkId()))
             .execute();

--- a/user-api/src/main/java/com/biengual/userapi/bookmark/infrastructure/BookmarkStoreImpl.java
+++ b/user-api/src/main/java/com/biengual/userapi/bookmark/infrastructure/BookmarkStoreImpl.java
@@ -28,7 +28,11 @@ public class BookmarkStoreImpl implements BookmarkStore {
 
 	@Override
 	public void deleteBookmark(BookmarkCommand.Delete command) {
-		bookmarkCustomRepository.deleteBookmark(command);
+		long execute = bookmarkCustomRepository.deleteBookmark(command);
+
+		if (execute < 1) {
+			throw new CommonException(BOOKMARK_NOT_FOUND);
+		}
 	}
 
 	@Override

--- a/user-api/src/main/java/com/biengual/userapi/content/domain/ContentInfo.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/domain/ContentInfo.java
@@ -46,6 +46,7 @@ public class ContentInfo {
 	@Builder
 	public record UserScript(
 		Script script,
+		Long bookmarkId,
 		Boolean isHighlighted,
 		String description
 	) {

--- a/user-api/src/main/java/com/biengual/userapi/content/domain/UserContentBookmarks.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/domain/UserContentBookmarks.java
@@ -25,6 +25,7 @@ public class UserContentBookmarks {
                 BookmarkEntity bookmark = bookmarkMapBySentenceIndex.get((long) i);
                 return ContentInfo.UserScript.builder()
                     .script(scripts.get(i))
+                    .bookmarkId(bookmark != null ? bookmark.getId() : null)
                     .isHighlighted(bookmark != null)
                     .description(bookmark != null ? bookmark.getDescription() : null)
                     .build();

--- a/user-api/src/main/java/com/biengual/userapi/content/presentation/ContentPublicController.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/presentation/ContentPublicController.java
@@ -93,7 +93,6 @@ public class ContentPublicController {
 		return ResponseEntityFactory.toResponseEntity(CONTENT_VIEW_SUCCESS, response);
 	}
 
-	// TODO: Approve가 된다면 Page 내용을 담는 key 값 변경 사항을 프론트에게 공유해야 합니다.
 	@GetMapping("/preview/paginated-reading")
 	@Operation(summary = "리딩 컨텐츠 프리뷰 페이지 조회", description = "페이지네이션을 적용하여 리딩 컨텐츠 목록을 조회합니다.")
 	@ApiResponses(value = {
@@ -125,7 +124,6 @@ public class ContentPublicController {
 		return ResponseEntityFactory.toResponseEntity(CONTENT_VIEW_SUCCESS, response);
 	}
 
-	// TODO: Approve가 된다면 Page 내용을 담는 key 값 변경 사항을 프론트에게 공유해야 합니다.
 	@GetMapping("/preview/paginated-listening")
 	@Operation(summary = "리스닝 컨텐츠 프리뷰 페이지 조회", description = "페이지네이션을 적용하여 리스닝 컨텐츠 목록을 조회합니다.")
 	@ApiResponses(value = {

--- a/user-api/src/main/java/com/biengual/userapi/content/presentation/ContentResponseDto.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/presentation/ContentResponseDto.java
@@ -16,6 +16,7 @@ public class ContentResponseDto {
 		Double durationInSecond,
 		String enScript,
 		String koScript,
+		Long bookmarkId,
 		Boolean isHighlighted,
 		String description
 	) {


### PR DESCRIPTION
### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 리팩토링
- [ ] 스타일 수정
- [ ] 테스트 코드 추가
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 개발 환경 세팅

### 변경 사항
- dto와 info 멤버변수에 bookmarkId 추가
- 추가적으로 본인의 북마크가 삭제된 것이 아니면 예외를 던지도록 구현


### 참고 사항
- 관련 이슈 번호: #320 


### 셀프 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [ ] 새로운 테스트를 추가했거나 기존 테스트를 통과하는지 확인
- [ ] 코드 스타일 가이드에 맞게 포맷팅했는지 확인
- [ ] 관련 문서를 업데이트했는지 확인
