### PR TITLE
[REFACTOR] oauth2 인증 유효시간 3 -> 5분으로 변경

### DIFF
--- a/biengual-core/src/main/java/com/biengual/core/util/CookieUtil.java
+++ b/biengual-core/src/main/java/com/biengual/core/util/CookieUtil.java
@@ -24,7 +24,7 @@ public class CookieUtil {
 	public static final String RETURN_URL_NAME = "returnUrl";
 	public static final Duration ACCESS_TOKEN_COOKIE_EXPIRE = Duration.ofDays(1);
 	public static final Duration REFRESH_TOKEN_COOKIE_EXPIRE = Duration.ofDays(7);
-	public static final Duration OAUTH2_AUTHORIZATION_REQUEST_COOKIE_EXPIRE = Duration.ofMinutes(3);
+	public static final Duration OAUTH2_AUTHORIZATION_REQUEST_COOKIE_EXPIRE = Duration.ofMinutes(5);
 	public static final Duration RETURN_URL_NAME_COOKIE_EXPIRE = Duration.ofMinutes(3);
 
 	@Value("${spring.profiles.active}")


### PR DESCRIPTION
### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 리팩토링
- [ ] 스타일 수정
- [ ] 테스트 코드 추가
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 개발 환경 세팅

### 변경 사항
- 30초가 아니라 3분에서 -> 5 분으로 변경



### 참고 사항
- 관련 이슈 번호: #338 


### 셀프 체크리스트
- [ ] 코드가 정상적으로 동작하는지 확인
- [ ] 새로운 테스트를 추가했거나 기존 테스트를 통과하는지 확인
- [ ] 코드 스타일 가이드에 맞게 포맷팅했는지 확인
- [ ] 관련 문서를 업데이트했는지 확인
