### PR TITLE
[REFACTOR] 프론트 요청으로 인한 컨텐츠 디테일 조회 응답에 curentLearningRate와 completedLearningRate 추가

### DIFF
--- a/user-api/src/main/java/com/biengual/userapi/content/domain/ContentInfo.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/domain/ContentInfo.java
@@ -1,13 +1,12 @@
 package com.biengual.userapi.content.domain;
 
-import java.math.BigDecimal;
-import java.util.List;
-
 import com.biengual.core.domain.document.content.script.Script;
 import com.biengual.core.enums.ContentStatus;
 import com.biengual.core.enums.ContentType;
-
 import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.util.List;
 
 public class ContentInfo {
 
@@ -71,6 +70,19 @@ public class ContentInfo {
     }
 
     @Builder
+    public record LearningRateInfo(
+        BigDecimal currentLearningRate,
+        BigDecimal completedLearningRate
+    ) {
+        public static LearningRateInfo createInitLearningRateInfo() {
+            return LearningRateInfo.builder()
+                .currentLearningRate(BigDecimal.ZERO)
+                .completedLearningRate(BigDecimal.ZERO)
+                .build();
+        }
+    }
+
+    @Builder
     public record Detail(
         Long contentId,
         ContentType contentType,
@@ -81,7 +93,8 @@ public class ContentInfo {
         Integer videoDurationInSeconds,
         Integer hits,
         Boolean isScrapped,
-        BigDecimal learningRate,
+        BigDecimal currentLearningRate,
+        BigDecimal completedLearningRate,
         List<UserScript> scriptList
     ) {
     }

--- a/user-api/src/main/java/com/biengual/userapi/content/infrastructure/ContentReaderImpl.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/infrastructure/ContentReaderImpl.java
@@ -1,15 +1,5 @@
 package com.biengual.userapi.content.infrastructure;
 
-import static com.biengual.core.constant.RestrictionConstant.*;
-import static com.biengual.core.response.error.code.ContentErrorCode.*;
-
-import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.util.List;
-
-import org.bson.types.ObjectId;
-import org.springframework.data.domain.Page;
-
 import com.biengual.core.annotation.DataProvider;
 import com.biengual.core.domain.document.content.ContentDocument;
 import com.biengual.core.domain.document.content.script.Script;
@@ -19,19 +9,21 @@ import com.biengual.core.enums.ContentStatus;
 import com.biengual.core.response.error.exception.CommonException;
 import com.biengual.core.util.PaginationInfo;
 import com.biengual.userapi.bookmark.domain.BookmarkRepository;
-import com.biengual.userapi.content.domain.ContentCommand;
-import com.biengual.userapi.content.domain.ContentCustomRepository;
-import com.biengual.userapi.content.domain.ContentDocumentRepository;
-import com.biengual.userapi.content.domain.ContentInfo;
-import com.biengual.userapi.content.domain.ContentReader;
-import com.biengual.userapi.content.domain.ContentRepository;
-import com.biengual.userapi.content.domain.UserContentBookmarks;
+import com.biengual.userapi.content.domain.*;
 import com.biengual.userapi.content.presentation.ContentDtoMapper;
 import com.biengual.userapi.learning.domain.RecentLearningHistoryCustomRepository;
 import com.biengual.userapi.payment.domain.PaymentReader;
 import com.biengual.userapi.scrap.domain.ScrapCustomRepository;
-
 import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
+import org.springframework.data.domain.Page;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.biengual.core.constant.RestrictionConstant.PERIOD_FOR_POINT_CONTENT_ACCESS;
+import static com.biengual.core.response.error.code.ContentErrorCode.CONTENT_IS_DEACTIVATED;
+import static com.biengual.core.response.error.code.ContentErrorCode.CONTENT_NOT_FOUND;
 
 @DataProvider
 @RequiredArgsConstructor
@@ -140,12 +132,12 @@ public class ContentReaderImpl implements ContentReader {
 
             boolean isScrapped = scrapCustomRepository.existsScrap(command.userId(), command.contentId());
 
-            BigDecimal learningRate =
+            ContentInfo.LearningRateInfo learningRateInfo =
                 recentLearningHistoryCustomRepository
                     .findLearningRateByUserIdAndContentId(command.userId(), command.contentId())
-                    .orElse(BigDecimal.ZERO);
+                    .orElse(ContentInfo.LearningRateInfo.createInitLearningRateInfo());
 
-            return contentDtoMapper.buildDetail(content, isScrapped, learningRate, userScripts);
+            return contentDtoMapper.buildDetail(content, isScrapped, learningRateInfo, userScripts);
         }
 
         return contentDtoMapper.buildDetail(content, ContentInfo.UserScript.toResponse(scripts));

--- a/user-api/src/main/java/com/biengual/userapi/content/presentation/ContentDtoMapper.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/presentation/ContentDtoMapper.java
@@ -1,13 +1,5 @@
 package com.biengual.userapi.content.presentation;
 
-import java.math.BigDecimal;
-import java.util.List;
-
-import org.mapstruct.*;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-
 import com.biengual.core.domain.document.content.script.Script;
 import com.biengual.core.domain.document.content.script.YoutubeScript;
 import com.biengual.core.domain.entity.content.ContentEntity;
@@ -16,6 +8,12 @@ import com.biengual.core.util.PaginationInfo;
 import com.biengual.userapi.content.domain.ContentCommand;
 import com.biengual.userapi.content.domain.ContentInfo;
 import com.biengual.userapi.oauth2.info.OAuth2UserPrincipal;
+import org.mapstruct.*;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
 
 /**
  * do~ : Command <- Request
@@ -133,7 +131,8 @@ public interface ContentDtoMapper {
 	@Mapping(target = "videoUrl", source = "content", qualifiedByName = "toVideoUrl")
 	@Mapping(target = "category", source = "content.category.name")
 	@Mapping(target = "isScrapped", constant = "false")
-	@Mapping(target = "learningRate", ignore = true)
+	@Mapping(target = "currentLearningRate", ignore = true)
+	@Mapping(target = "completedLearningRate", ignore = true)
 	@Mapping(target = "scriptList", source = "userScripts")
 	@Mapping(target = "videoDurationInSeconds", source = "content.videoDuration")
 	ContentInfo.Detail buildDetail(ContentEntity content, List<ContentInfo.UserScript> userScripts);
@@ -142,11 +141,12 @@ public interface ContentDtoMapper {
 	@Mapping(target = "videoUrl", source = "content", qualifiedByName = "toVideoUrl")
 	@Mapping(target = "category", source = "content.category.name")
 	@Mapping(target = "isScrapped", source = "isScrapped")
-	@Mapping(target = "learningRate", source = "learningRate")
+	@Mapping(target = "currentLearningRate", source = "learningRateInfo.currentLearningRate")
+	@Mapping(target = "completedLearningRate", source = "learningRateInfo.completedLearningRate")
 	@Mapping(target = "scriptList", source = "userScripts")
 	@Mapping(target = "videoDurationInSeconds", source = "content.videoDuration")
 	ContentInfo.Detail buildDetail(
-		ContentEntity content, Boolean isScrapped, BigDecimal learningRate, List<ContentInfo.UserScript> userScripts
+		ContentEntity content, Boolean isScrapped, ContentInfo.LearningRateInfo learningRateInfo, List<ContentInfo.UserScript> userScripts
 	);
 
 	// Internal Method =================================================================================================

--- a/user-api/src/main/java/com/biengual/userapi/content/presentation/ContentResponseDto.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/presentation/ContentResponseDto.java
@@ -1,5 +1,6 @@
 package com.biengual.userapi.content.presentation;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 import com.biengual.core.enums.ContentStatus;
@@ -35,7 +36,8 @@ public class ContentResponseDto {
 		String duration,
 		Integer hits,
 		Boolean isScrapped,
-		Integer learningRate,
+		BigDecimal currentLearningRate,
+		BigDecimal completedLearningRate,
 		List<UserScript> scriptList
 	) {
 	}

--- a/user-api/src/main/java/com/biengual/userapi/learning/domain/RecentLearningHistoryCustomRepository.java
+++ b/user-api/src/main/java/com/biengual/userapi/learning/domain/RecentLearningHistoryCustomRepository.java
@@ -11,7 +11,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,14 +24,20 @@ public class RecentLearningHistoryCustomRepository {
     private final JPAQueryFactory queryFactory;
 
     // 해당 컨텐츠의 유저 현재 학습률을 조회하기 위한 쿼리
-    public Optional<BigDecimal> findLearningRateByUserIdAndContentId(Long userId, Long contentId) {
+    public Optional<ContentInfo.LearningRateInfo> findLearningRateByUserIdAndContentId(Long userId, Long contentId) {
         return Optional.ofNullable(
             queryFactory
-            .select(recentLearningHistoryEntity.currentLearningRate)
-            .from(recentLearningHistoryEntity)
+                .select(
+                    Projections.constructor(
+                        ContentInfo.LearningRateInfo.class,
+                        recentLearningHistoryEntity.currentLearningRate,
+                        recentLearningHistoryEntity.completedLearningRate
+                    )
+                )
+                .from(recentLearningHistoryEntity)
                 .where(recentLearningHistoryEntity.userId.eq(userId)
                     .and(recentLearningHistoryEntity.contentId.eq(contentId)))
-            .fetchOne()
+                .fetchOne()
         );
     }
 


### PR DESCRIPTION
### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 리팩토링
- [ ] 스타일 수정
- [ ] 테스트 코드 추가
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 개발 환경 세팅

### 변경 사항
- Dto, Info 구조 변경
- Mapper, Reader 로직 변경


### 참고 사항
- 관련 이슈 번호: #381 
- 기존 learningRate 대신 curentLearningRate와 completedLearningRate 사용합니다.


### 셀프 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [ ] 새로운 테스트를 추가했거나 기존 테스트를 통과하는지 확인
- [x] 코드 스타일 가이드에 맞게 포맷팅했는지 확인
- [ ] 관련 문서를 업데이트했는지 확인
