### PR TITLE
[REFACTOR] 프론트 요청에 따라 본인 정보 수정 시 CategoryIds를 Optional하게 요청할 수 있게 수정

### DIFF
--- a/biengual-core/src/main/java/com/biengual/core/constant/BadRequestMessageConstant.java
+++ b/biengual-core/src/main/java/com/biengual/core/constant/BadRequestMessageConstant.java
@@ -6,7 +6,6 @@ package com.biengual.core.constant;
  * @author 문찬욱
  */
 public class BadRequestMessageConstant {
-    public static final String NULL_CATEGORY_LIST_ERROR_MESSAGE = "카테고리 목록의 null 허용 불가";
     public static final String MAX_CATEGORY_SELECTION_ERROR_MESSAGE = "카테고리 목록은 최대 5개 선택 가능";
     public static final String BLANK_CONTENT_KEYWORD_ERROR_MESSAGE = "컨테츠 검색 키워드 blank 허용 불가";
     public static final String NULL_MISSION_LIST_ERROR_MESSAGE = "미션 체크 목록 null 허용 불가";

--- a/user-api/src/main/java/com/biengual/userapi/user/application/UserFacade.java
+++ b/user-api/src/main/java/com/biengual/userapi/user/application/UserFacade.java
@@ -26,11 +26,6 @@ public class UserFacade {
         return userService.getMyInfo(userId);
     }
 
-    // 본인 정보 수정
-    public void updateMyInfo(UserCommand.UpdateMyInfo command) {
-        userService.updateMyInfo(command);
-    }
-
     // 본인 회원가입 날짜 조회
     public UserInfo.MySignUpTime getMySignUpTime(Long userId) {
         return userService.getMySignUpTime(userId);

--- a/user-api/src/main/java/com/biengual/userapi/user/infrastructure/UserStoreImpl.java
+++ b/user-api/src/main/java/com/biengual/userapi/user/infrastructure/UserStoreImpl.java
@@ -41,13 +41,15 @@ public class UserStoreImpl implements UserStore {
             command.username(), command.nickname(), command.phoneNumber(), command.birth(), command.gender()
         );
 
-        // user가 이미 관심 카테고리로 등록한 CategoryIds List
-        List<Long> alreadyRegisteredMyCategoryIds =
-            userCategoryCustomRepository.findAllMyRegisteredCategoryId(command.userId());
+        if (command.categoryIds() != null) {
+            // user가 이미 관심 카테고리로 등록한 CategoryIds List
+            List<Long> alreadyRegisteredMyCategoryIds =
+                userCategoryCustomRepository.findAllMyRegisteredCategoryId(command.userId());
 
-        saveAdditionalMyCategories(alreadyRegisteredMyCategoryIds, command);
+            saveAdditionalMyCategories(alreadyRegisteredMyCategoryIds, command);
 
-        deleteRemovalMyCategoryIds(alreadyRegisteredMyCategoryIds, command);
+            deleteRemovalMyCategoryIds(alreadyRegisteredMyCategoryIds, command);
+        }
     }
 
     @Override

--- a/user-api/src/main/java/com/biengual/userapi/user/presentation/UserPublicController.java
+++ b/user-api/src/main/java/com/biengual/userapi/user/presentation/UserPublicController.java
@@ -6,6 +6,7 @@ import com.biengual.core.response.ResponseEntityFactory;
 import com.biengual.core.swagger.SwaggerBooleanReturn;
 import com.biengual.core.swagger.SwaggerVoidReturn;
 import com.biengual.userapi.oauth2.info.OAuth2UserPrincipal;
+import com.biengual.userapi.user.domain.UserService;
 import com.biengual.userapi.user.presentation.swagger.SwaggerUserMyPage;
 import com.biengual.userapi.user.presentation.swagger.SwaggerUserMyTime;
 import com.biengual.userapi.user.application.UserFacade;
@@ -34,6 +35,7 @@ public class UserPublicController {
 
 	private final UserDtoMapper userDtoMapper;
 	private final UserFacade userFacade;
+	private final UserService userService;
 
 	@GetMapping("/me")
 	@Operation(summary = "본인 정보 조회", description = "유저가 본인의 정보를 조회합니다.")
@@ -70,7 +72,7 @@ public class UserPublicController {
 		UserRequestDto.UpdateMyInfoReq request
 	) {
 		UserCommand.UpdateMyInfo command = userDtoMapper.doUpdateMyInfo(request, principal);
-		userFacade.updateMyInfo(command);
+		userService.updateMyInfo(command);
 
 		return ResponseEntityFactory.toResponseEntity(USER_UPDATE_INFO);
 	}

--- a/user-api/src/main/java/com/biengual/userapi/user/presentation/UserRequestDto.java
+++ b/user-api/src/main/java/com/biengual/userapi/user/presentation/UserRequestDto.java
@@ -21,7 +21,6 @@ public class UserRequestDto {
 		String phoneNumber,
 		LocalDate birth,
 		Gender gender,
-		@NotNull(message = NULL_CATEGORY_LIST_ERROR_MESSAGE)
 		@Size(max = MAX_CATEGORY_SELECTION_LIMIT, message = MAX_CATEGORY_SELECTION_ERROR_MESSAGE)
 		List<Long> categories
 	) {


### PR DESCRIPTION
### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 리팩토링
- [ ] 스타일 수정
- [ ] 테스트 코드 추가
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 개발 환경 세팅

### 변경 사항
- Dto의 NotNull 제거
- DataProvider에서 null 체크 로직 추가
- 해당 기능의 Facade  메서드 제거하고 Controller에서 해당 기능의 Service 메서드 호출


### 참고 사항
- 관련 이슈 번호: #404 


### 셀프 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [ ] 새로운 테스트를 추가했거나 기존 테스트를 통과하는지 확인
- [x] 코드 스타일 가이드에 맞게 포맷팅했는지 확인
- [ ] 관련 문서를 업데이트했는지 확인
