### PR TITLE
[BUGFIX] ContentStatus를 반대로 체크하던 것을 수정

### DIFF
--- a/biengual-core/src/main/java/com/biengual/core/domain/entity/content/ContentEntity.java
+++ b/biengual-core/src/main/java/com/biengual/core/domain/entity/content/ContentEntity.java
@@ -123,8 +123,8 @@ public class ContentEntity extends BaseEntity {
 		return false;
 	}
 
-	public boolean isActivated() {
-		return Objects.equals(this.contentStatus, ContentStatus.ACTIVATED);
+	public boolean isDeactivated() {
+		return Objects.equals(this.contentStatus, ContentStatus.DEACTIVATED);
 	}
 
 	// Internal Method =================================================================================================

--- a/user-api/src/main/java/com/biengual/userapi/validator/ContentValidator.java
+++ b/user-api/src/main/java/com/biengual/userapi/validator/ContentValidator.java
@@ -22,7 +22,7 @@ public class ContentValidator {
 
     // 해당 컨텐츠가 학습할 수 있는 컨텐츠인지 검증
     public void verifyLearnableContent(ContentEntity content, Long userId) {
-        if (content.isActivated()) {
+        if (content.isDeactivated()) {
             throw new CommonException(CONTENT_IS_DEACTIVATED);
         }
 


### PR DESCRIPTION
### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 리팩토링
- [ ] 스타일 수정
- [ ] 테스트 코드 추가
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 개발 환경 세팅

### 변경 사항
- ContentValidator의 verifyLearnableContent메서드에서 ContentStatus를 반대로 체크하던 것을 수정


### 참고 사항
- 관련 이슈 번호: #406 


### 셀프 체크리스트
- [ ] 코드가 정상적으로 동작하는지 확인
- [ ] 새로운 테스트를 추가했거나 기존 테스트를 통과하는지 확인
- [ ] 코드 스타일 가이드에 맞게 포맷팅했는지 확인
- [ ] 관련 문서를 업데이트했는지 확인
