### PR TITLE
[FEAT] 컨텐츠 난이도 피드백 내역 집계 기능 개발

### DIFF
--- a/biengual-core/src/main/java/com/biengual/core/constant/ServiceConstant.java
+++ b/biengual-core/src/main/java/com/biengual/core/constant/ServiceConstant.java
@@ -1,5 +1,7 @@
 package com.biengual.core.constant;
 
+import java.time.LocalDateTime;
+
 /**
  *  서비스에 사용하는 상수 관리 클래스
  *
@@ -7,4 +9,6 @@ package com.biengual.core.constant;
  */
 public class ServiceConstant {
     public static final String UNKNOWN_CATEGORY_NAME = "Unknown";
+    public static final String CONTENT_LEVEL_FEEDBACK_HISTORY_TABLE = "content_level_feedback_history";
+    public static final LocalDateTime BIENGUAL_SERVICE_START_TIME = LocalDateTime.of(2024, 9, 9, 4, 0);
 }

--- a/biengual-core/src/main/java/com/biengual/core/domain/entity/content/ContentEntity.java
+++ b/biengual-core/src/main/java/com/biengual/core/domain/entity/content/ContentEntity.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 
+import com.biengual.core.enums.ContentLevel;
 import org.hibernate.annotations.DynamicUpdate;
 
 import com.biengual.core.domain.document.content.script.Script;
@@ -80,6 +81,10 @@ public class ContentEntity extends BaseEntity {
 
 	@Column(columnDefinition = "smallint")
 	private Integer videoDuration;
+
+	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
+	private ContentLevel contentLevel;
 
 	@Builder
 	public ContentEntity(

--- a/biengual-core/src/main/java/com/biengual/core/domain/entity/content/ContentLevelFeedbackDataMart.java
+++ b/biengual-core/src/main/java/com/biengual/core/domain/entity/content/ContentLevelFeedbackDataMart.java
@@ -1,0 +1,42 @@
+package com.biengual.core.domain.entity.content;
+
+import com.biengual.core.domain.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * AggregationTime까지의 ContentLevelFeedback에 대한 집계를 보여주기 위한 DataMart 엔티티
+ *
+ * @author 문찬욱
+ */
+@Getter
+@Entity
+@Table(name = "content_level_feedback_data_mart")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ContentLevelFeedbackDataMart extends BaseEntity {
+    @Id
+    @Column(name = "id")
+    private Long contentId;
+
+    @Column(nullable = false, columnDefinition = "bigint")
+    private Long levelLowCount;
+
+    @Column(nullable = false, columnDefinition = "bigint")
+    private Long levelMediumCount;
+
+    @Column(nullable = false, columnDefinition = "bigint")
+    private Long levelHighCount;
+
+    @Column(nullable = false, columnDefinition = "bigint")
+    private Long feedbackTotalCount;
+
+    @Column(nullable = false)
+    private LocalDateTime aggregationTime;
+}

--- a/biengual-core/src/main/java/com/biengual/core/domain/entity/content/ContentLevelFeedbackDataMart.java
+++ b/biengual-core/src/main/java/com/biengual/core/domain/entity/content/ContentLevelFeedbackDataMart.java
@@ -20,7 +20,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ContentLevelFeedbackDataMart {
     @Id
-    @Column(name = "id")
     private Long contentId;
 
     @Column(nullable = false, columnDefinition = "bigint")

--- a/biengual-core/src/main/java/com/biengual/core/domain/entity/content/ContentLevelFeedbackDataMart.java
+++ b/biengual-core/src/main/java/com/biengual/core/domain/entity/content/ContentLevelFeedbackDataMart.java
@@ -1,6 +1,5 @@
 package com.biengual.core.domain.entity.content;
 
-import com.biengual.core.domain.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -9,10 +8,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 /**
- * AggregationTime까지의 ContentLevelFeedback에 대한 집계를 보여주기 위한 DataMart 엔티티
+ * ContentLevelFeedback에 대한 집계를 보여주기 위한 DataMart 엔티티
  *
  * @author 문찬욱
  */
@@ -20,7 +17,7 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "content_level_feedback_data_mart")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ContentLevelFeedbackDataMart extends BaseEntity {
+public class ContentLevelFeedbackDataMart {
     @Id
     @Column(name = "id")
     private Long contentId;
@@ -36,7 +33,4 @@ public class ContentLevelFeedbackDataMart extends BaseEntity {
 
     @Column(nullable = false, columnDefinition = "bigint")
     private Long feedbackTotalCount;
-
-    @Column(nullable = false)
-    private LocalDateTime aggregationTime;
 }

--- a/biengual-core/src/main/java/com/biengual/core/domain/entity/content/ContentLevelFeedbackDataMart.java
+++ b/biengual-core/src/main/java/com/biengual/core/domain/entity/content/ContentLevelFeedbackDataMart.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -33,4 +34,27 @@ public class ContentLevelFeedbackDataMart {
 
     @Column(nullable = false, columnDefinition = "bigint")
     private Long feedbackTotalCount;
+
+    @Builder
+    public ContentLevelFeedbackDataMart(
+        Long contentId, Long levelLowCount, Long levelMediumCount, Long levelHighCount, Long feedbackTotalCount
+    ) {
+        this.contentId = contentId;
+        this.levelLowCount = levelLowCount;
+        this.levelMediumCount = levelMediumCount;
+        this.levelHighCount = levelHighCount;
+        this.feedbackTotalCount = feedbackTotalCount;
+    }
+
+    public static ContentLevelFeedbackDataMart createEntity(
+        Long contentId, Long levelLowCount, Long levelMediumCount, Long levelHighCount, Long feedbackTotalCount
+    ) {
+        return ContentLevelFeedbackDataMart.builder()
+            .contentId(contentId)
+            .levelLowCount(levelLowCount)
+            .levelMediumCount(levelMediumCount)
+            .levelHighCount(levelHighCount)
+            .feedbackTotalCount(feedbackTotalCount)
+            .build();
+    }
 }

--- a/biengual-core/src/main/java/com/biengual/core/domain/entity/content/ContentLevelFeedbackHistoryEntity.java
+++ b/biengual-core/src/main/java/com/biengual/core/domain/entity/content/ContentLevelFeedbackHistoryEntity.java
@@ -1,6 +1,5 @@
 package com.biengual.core.domain.entity.content;
 
-import com.biengual.core.domain.entity.BaseEntity;
 import com.biengual.core.enums.ContentLevel;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -8,11 +7,15 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
+import static com.biengual.core.constant.ServiceConstant.CONTENT_LEVEL_FEEDBACK_HISTORY_TABLE;
+
 @Getter
 @Entity
-@Table(name = "content_level_feedback_history")
+@Table(name = CONTENT_LEVEL_FEEDBACK_HISTORY_TABLE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ContentLevelFeedbackHistoryEntity extends BaseEntity {
+public class ContentLevelFeedbackHistoryEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -27,21 +30,28 @@ public class ContentLevelFeedbackHistoryEntity extends BaseEntity {
     @Column(nullable = false)
     private ContentLevel contentLevel;
 
+    @Column(nullable = false, columnDefinition = "datetime(6)")
+    private LocalDateTime feedbackTime;
+
     @Builder
     public ContentLevelFeedbackHistoryEntity(
-        Long id, Long userId, Long contentId, ContentLevel contentLevel
+        Long id, Long userId, Long contentId, ContentLevel contentLevel, LocalDateTime feedbackTime
     ) {
         this.id = id;
         this.userId = userId;
         this.contentId = contentId;
         this.contentLevel = contentLevel;
+        this.feedbackTime = feedbackTime;
     }
 
-    public static ContentLevelFeedbackHistoryEntity createEntity(Long userId, Long contentId, ContentLevel contentLevel) {
+    public static ContentLevelFeedbackHistoryEntity createEntity(
+        Long userId, Long contentId, ContentLevel contentLevel
+    ) {
         return ContentLevelFeedbackHistoryEntity.builder()
             .userId(userId)
             .contentId(contentId)
             .contentLevel(contentLevel)
+            .feedbackTime(LocalDateTime.now())
             .build();
     }
 }

--- a/biengual-core/src/main/java/com/biengual/core/domain/entity/metadata/AggregationMetadataEntity.java
+++ b/biengual-core/src/main/java/com/biengual/core/domain/entity/metadata/AggregationMetadataEntity.java
@@ -33,7 +33,7 @@ public class AggregationMetadataEntity extends BaseEntity {
     private String tableName;
 
     @Column(nullable = false, columnDefinition = "datetime(6)")
-    private LocalDateTime aggregateEndTime;
+    private LocalDateTime nextAggTime;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -44,11 +44,11 @@ public class AggregationMetadataEntity extends BaseEntity {
 
     @Builder
     public AggregationMetadataEntity(
-        Long id, String tableName, LocalDateTime aggregateEndTime, IntervalType intervalType, Integer intervalNumber
+        Long id, String tableName, LocalDateTime nextAggTime, IntervalType intervalType, Integer intervalNumber
     ) {
         this.id = id;
         this.tableName = tableName;
-        this.aggregateEndTime = aggregateEndTime;
+        this.nextAggTime = nextAggTime;
         this.intervalType = intervalType;
         this.intervalNumber = intervalNumber;
     }
@@ -64,8 +64,8 @@ public class AggregationMetadataEntity extends BaseEntity {
         }
     }
 
-    public void updateAggregateEndTime(LocalDateTime aggregateEndTime) {
-        this.aggregateEndTime = aggregateEndTime;
+    public void updateNextAggTime(LocalDateTime nextAggTime) {
+        this.nextAggTime = nextAggTime;
     }
 
     // Internal Method =================================================================================================
@@ -75,7 +75,7 @@ public class AggregationMetadataEntity extends BaseEntity {
     ) {
         return AggregationMetadataEntity.builder()
             .tableName(tableName)
-            .aggregateEndTime(BIENGUAL_SERVICE_START_TIME)
+            .nextAggTime(BIENGUAL_SERVICE_START_TIME)
             .intervalType(intervalType)
             .intervalNumber(intervalNumber)
             .build();

--- a/biengual-core/src/main/java/com/biengual/core/domain/entity/metadata/AggregationMetadataEntity.java
+++ b/biengual-core/src/main/java/com/biengual/core/domain/entity/metadata/AggregationMetadataEntity.java
@@ -1,0 +1,38 @@
+package com.biengual.core.domain.entity.metadata;
+
+import com.biengual.core.domain.entity.BaseEntity;
+import com.biengual.core.enums.IntervalType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 집계 유형의 메타데이터를 저장하기 위한 엔티티
+ *
+ * @author 문찬욱
+ */
+@Getter
+@Entity
+@Table(name = "aggregation_metadata")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AggregationMetadataEntity extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, columnDefinition = "varchar(100)")
+    private String tableName;
+
+    @Column(nullable = false, columnDefinition = "datetime(6)")
+    private LocalDateTime aggregateEndTime;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private IntervalType intervalType;
+
+    @Column(nullable = false, columnDefinition = "tinyint")
+    private Integer interval;
+}

--- a/biengual-core/src/main/java/com/biengual/core/domain/entity/metadata/AggregationMetadataEntity.java
+++ b/biengual-core/src/main/java/com/biengual/core/domain/entity/metadata/AggregationMetadataEntity.java
@@ -16,7 +16,7 @@ import static com.biengual.core.constant.ServiceConstant.CONTENT_LEVEL_FEEDBACK_
 import static com.biengual.core.response.error.code.MetadataErrorCode.NOT_AGGREGATION_TABLE;
 
 /**
- * 집계 유형의 메타데이터를 저장하기 위한 엔티티
+ * 집계 테이블의 메타데이터를 저장하기 위한 엔티티
  *
  * @author 문찬욱
  */

--- a/biengual-core/src/main/java/com/biengual/core/domain/entity/metadata/AggregationMetadataEntity.java
+++ b/biengual-core/src/main/java/com/biengual/core/domain/entity/metadata/AggregationMetadataEntity.java
@@ -40,17 +40,17 @@ public class AggregationMetadataEntity extends BaseEntity {
     private IntervalType intervalType;
 
     @Column(nullable = false, columnDefinition = "tinyint")
-    private Integer interval;
+    private Integer intervalNumber;
 
     @Builder
     public AggregationMetadataEntity(
-        Long id, String tableName, LocalDateTime aggregateEndTime, IntervalType intervalType, Integer interval
+        Long id, String tableName, LocalDateTime aggregateEndTime, IntervalType intervalType, Integer intervalNumber
     ) {
         this.id = id;
         this.tableName = tableName;
         this.aggregateEndTime = aggregateEndTime;
         this.intervalType = intervalType;
-        this.interval = interval;
+        this.intervalNumber = intervalNumber;
     }
 
     // TODO: REST API가 아닌 백엔드 내부 로직에서 발생하는 예외인데, HttpStatus가 필요한지?
@@ -71,13 +71,13 @@ public class AggregationMetadataEntity extends BaseEntity {
     // Internal Method =================================================================================================
 
     private static AggregationMetadataEntity createEntity(
-        String tableName, IntervalType intervalType, Integer interval
+        String tableName, IntervalType intervalType, Integer intervalNumber
     ) {
         return AggregationMetadataEntity.builder()
             .tableName(tableName)
             .aggregateEndTime(BIENGUAL_SERVICE_START_TIME)
             .intervalType(intervalType)
-            .interval(interval)
+            .intervalNumber(intervalNumber)
             .build();
     }
 }

--- a/biengual-core/src/main/java/com/biengual/core/enums/IntervalType.java
+++ b/biengual-core/src/main/java/com/biengual/core/enums/IntervalType.java
@@ -1,0 +1,9 @@
+package com.biengual.core.enums;
+
+public enum IntervalType {
+    YEARLY,
+    MONTHLY,
+    DAILY,
+    HOURLY,
+    ALL
+}

--- a/biengual-core/src/main/java/com/biengual/core/response/error/code/MetadataErrorCode.java
+++ b/biengual-core/src/main/java/com/biengual/core/response/error/code/MetadataErrorCode.java
@@ -1,0 +1,31 @@
+package com.biengual.core.response.error.code;
+
+import com.biengual.core.response.status.MetadataServiceStatus;
+import com.biengual.core.response.status.ServiceStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum MetadataErrorCode implements ErrorCode {
+    NOT_AGGREGATION_TABLE(HttpStatus.INTERNAL_SERVER_ERROR, MetadataServiceStatus.NOT_AGGREGATION_TABLE,
+        "집계하지 않는 테이블");
+
+    private final HttpStatus httpStatus;
+    private final ServiceStatus serviceStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return serviceStatus.getServiceStatus();
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/biengual-core/src/main/java/com/biengual/core/response/error/code/ServerError.java
+++ b/biengual-core/src/main/java/com/biengual/core/response/error/code/ServerError.java
@@ -5,9 +5,14 @@ import com.biengual.core.response.status.ServiceStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
+// TODO: Core의 Util에서 발생한 예외를 위한 ErrorCode 여기 있는게 맞는지?
 @RequiredArgsConstructor
 public enum ServerError implements ErrorCode {
-    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, ServerServiceStatus.SERVER_ERROR, "서버 에러");
+    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, ServerServiceStatus.SERVER_ERROR, "서버 에러"),
+    TIME_RANGE_IS_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, ServerServiceStatus.TIME_RANGE_IS_INVALID,
+        "유효하지 않은 시간 범위"),
+    INTERVAL_TYPE_IS_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, ServerServiceStatus.INTERVAL_TYPE_IS_INVALID,
+        "유효하지 않은 Interval Type");
 
     private final HttpStatus httpStatus;
     private final ServiceStatus serviceStatus;

--- a/biengual-core/src/main/java/com/biengual/core/response/status/MetadataServiceStatus.java
+++ b/biengual-core/src/main/java/com/biengual/core/response/status/MetadataServiceStatus.java
@@ -3,11 +3,9 @@ package com.biengual.core.response.status;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-public enum ServerServiceStatus implements ServiceStatus {
+public enum MetadataServiceStatus implements ServiceStatus {
     // failure
-    SERVER_ERROR("U-SV-901"),
-    TIME_RANGE_IS_INVALID("U-SV-902"),
-    INTERVAL_TYPE_IS_INVALID("U-SV-903");
+    NOT_AGGREGATION_TABLE("U-M-901");
 
     private final String code;
 

--- a/biengual-core/src/main/java/com/biengual/core/util/PeriodUtil.java
+++ b/biengual-core/src/main/java/com/biengual/core/util/PeriodUtil.java
@@ -1,10 +1,18 @@
 package com.biengual.core.util;
 
+import com.biengual.core.domain.entity.metadata.AggregationMetadataEntity;
+import com.biengual.core.enums.IntervalType;
+import com.biengual.core.response.error.exception.CommonException;
+
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+import static com.biengual.core.response.error.code.ServerError.INTERVAL_TYPE_IS_INVALID;
 
 /**
  * 쿼리에 사용하는 날짜별 조회를 위한 Util 클래스
@@ -39,5 +47,47 @@ public class PeriodUtil {
 
     public static LocalDate getFewWeeksAgo(LocalDate currentDate, long subtractWeek, DayOfWeek dayOfWeek) {
         return currentDate.minusWeeks(subtractWeek).with(TemporalAdjusters.previousOrSame(dayOfWeek));
+    }
+
+    public static Queue<TimeRange> getAggregationPeriodQueue(AggregationMetadataEntity aggregationMetadata) {
+        Queue<TimeRange> aggregationPeriodQueue = new ArrayDeque<>();
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime start = aggregationMetadata.getAggregateEndTime();
+        LocalDateTime end = calculateAggregateEndTime(
+            now, start, aggregationMetadata.getIntervalType(), aggregationMetadata.getInterval()
+        );
+
+        while (now.isAfter(end) || now.isEqual(end)) {
+            TimeRange timeRange = TimeRange.of(start, end);
+
+            aggregationPeriodQueue.add(timeRange);
+
+            start = end;
+            end = calculateAggregateEndTime(
+                now, start, aggregationMetadata.getIntervalType(), aggregationMetadata.getInterval()
+            );
+        }
+
+        return aggregationPeriodQueue;
+    }
+
+    // Internal Method =================================================================================================
+
+    private static LocalDateTime calculateAggregateEndTime(LocalDateTime now, LocalDateTime start, IntervalType intervalType, Integer interval) {
+        switch (intervalType) {
+            case YEARLY:
+                return start.plusYears(interval);
+            case MONTHLY:
+                return start.plusMonths(interval);
+            case DAILY:
+                return start.plusDays(interval);
+            case HOURLY:
+                return start.plusHours(interval);
+            case ALL:
+                return now;
+            default:
+                throw new CommonException(INTERVAL_TYPE_IS_INVALID);
+        }
     }
 }

--- a/biengual-core/src/main/java/com/biengual/core/util/PeriodUtil.java
+++ b/biengual-core/src/main/java/com/biengual/core/util/PeriodUtil.java
@@ -53,7 +53,7 @@ public class PeriodUtil {
         Queue<TimeRange> aggregationPeriodQueue = new ArrayDeque<>();
 
         LocalDateTime now = LocalDateTime.now();
-        LocalDateTime start = aggregationMetadata.getAggregateEndTime();
+        LocalDateTime start = aggregationMetadata.getNextAggTime();
         LocalDateTime end = calculateAggregateEndTime(
             now, start, aggregationMetadata.getIntervalType(), aggregationMetadata.getIntervalNumber()
         );

--- a/biengual-core/src/main/java/com/biengual/core/util/PeriodUtil.java
+++ b/biengual-core/src/main/java/com/biengual/core/util/PeriodUtil.java
@@ -58,7 +58,7 @@ public class PeriodUtil {
             now, start, aggregationMetadata.getIntervalType(), aggregationMetadata.getIntervalNumber()
         );
 
-        while (now.isAfter(end) || now.isEqual(end)) {
+        while (!now.isBefore(end) && !start.isEqual(end)) {
             TimeRange timeRange = TimeRange.of(start, end);
 
             aggregationPeriodQueue.add(timeRange);
@@ -85,7 +85,7 @@ public class PeriodUtil {
             case HOURLY:
                 return start.plusHours(interval);
             case ALL:
-                return now;
+                return now.withMinute(0).withSecond(0).withNano(0);
             default:
                 throw new CommonException(INTERVAL_TYPE_IS_INVALID);
         }

--- a/biengual-core/src/main/java/com/biengual/core/util/PeriodUtil.java
+++ b/biengual-core/src/main/java/com/biengual/core/util/PeriodUtil.java
@@ -55,7 +55,7 @@ public class PeriodUtil {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime start = aggregationMetadata.getAggregateEndTime();
         LocalDateTime end = calculateAggregateEndTime(
-            now, start, aggregationMetadata.getIntervalType(), aggregationMetadata.getInterval()
+            now, start, aggregationMetadata.getIntervalType(), aggregationMetadata.getIntervalNumber()
         );
 
         while (now.isAfter(end) || now.isEqual(end)) {
@@ -65,7 +65,7 @@ public class PeriodUtil {
 
             start = end;
             end = calculateAggregateEndTime(
-                now, start, aggregationMetadata.getIntervalType(), aggregationMetadata.getInterval()
+                now, start, aggregationMetadata.getIntervalType(), aggregationMetadata.getIntervalNumber()
             );
         }
 

--- a/biengual-core/src/main/java/com/biengual/core/util/TimeRange.java
+++ b/biengual-core/src/main/java/com/biengual/core/util/TimeRange.java
@@ -1,0 +1,27 @@
+package com.biengual.core.util;
+
+import com.biengual.core.response.error.exception.CommonException;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+import static com.biengual.core.response.error.code.ServerError.TIME_RANGE_IS_INVALID;
+
+@Builder
+public record TimeRange(
+    LocalDateTime start,
+    LocalDateTime end
+) {
+    public TimeRange {
+        if (start.isAfter(end) || start.isEqual(end)) {
+            throw new CommonException(TIME_RANGE_IS_INVALID);
+        }
+    }
+
+    public static TimeRange of(LocalDateTime start, LocalDateTime end) {
+        return TimeRange.builder()
+            .start(start)
+            .end(end)
+            .build();
+    }
+}

--- a/user-api/src/main/java/com/biengual/userapi/content/domain/ContentInfo.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/domain/ContentInfo.java
@@ -1,6 +1,7 @@
 package com.biengual.userapi.content.domain;
 
 import com.biengual.core.domain.document.content.script.Script;
+import com.biengual.core.domain.entity.content.ContentLevelFeedbackDataMart;
 import com.biengual.core.enums.ContentStatus;
 import com.biengual.core.enums.ContentType;
 import lombok.Builder;
@@ -111,4 +112,21 @@ public class ContentInfo {
     ) {
     }
 
+    public record AggregatedLevelFeedback(
+        Long contentId,
+        Long levelLowCount,
+        Long levelMediumCount,
+        Long levelHighCount,
+        Long feedbackTotalCount
+    ) {
+        public ContentLevelFeedbackDataMart toContentLevelFeedbackDataMart() {
+            return ContentLevelFeedbackDataMart.createEntity(
+                this.contentId,
+                this.levelLowCount,
+                this.levelMediumCount,
+                this.levelHighCount,
+                this.feedbackTotalCount
+            );
+        }
+    }
 }

--- a/user-api/src/main/java/com/biengual/userapi/content/domain/ContentLevelFeedbackDataMartCustomRepository.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/domain/ContentLevelFeedbackDataMartCustomRepository.java
@@ -1,0 +1,37 @@
+package com.biengual.userapi.content.domain;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import static com.biengual.core.domain.entity.content.QContentLevelFeedbackDataMart.contentLevelFeedbackDataMart;
+
+@Repository
+@RequiredArgsConstructor
+public class ContentLevelFeedbackDataMartCustomRepository {
+    private final JPAQueryFactory queryFactory;
+
+    // 기존 집계 데이터에 추가로 집계된 ContentLevelFeedback 데이터를 더하기 위한 쿼리
+    public void updateByAggregatedLevelFeedbackInfo(ContentInfo.AggregatedLevelFeedback info) {
+        queryFactory
+            .update(contentLevelFeedbackDataMart)
+            .set(
+                contentLevelFeedbackDataMart.levelHighCount,
+                contentLevelFeedbackDataMart.levelHighCount.add(info.levelHighCount())
+            )
+            .set(
+                contentLevelFeedbackDataMart.levelMediumCount,
+                contentLevelFeedbackDataMart.levelMediumCount.add(info.levelMediumCount())
+            )
+            .set(
+                contentLevelFeedbackDataMart.levelLowCount,
+                contentLevelFeedbackDataMart.levelLowCount.add(info.levelLowCount())
+            )
+            .set(
+                contentLevelFeedbackDataMart.feedbackTotalCount,
+                contentLevelFeedbackDataMart.feedbackTotalCount.add(info.feedbackTotalCount())
+            )
+            .where(contentLevelFeedbackDataMart.contentId.eq(info.contentId()))
+            .execute();
+    }
+}

--- a/user-api/src/main/java/com/biengual/userapi/content/domain/ContentLevelFeedbackDataMartRepository.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/domain/ContentLevelFeedbackDataMartRepository.java
@@ -1,0 +1,7 @@
+package com.biengual.userapi.content.domain;
+
+import com.biengual.core.domain.entity.content.ContentLevelFeedbackDataMart;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContentLevelFeedbackDataMartRepository extends JpaRepository<ContentLevelFeedbackDataMart, Long> {
+}

--- a/user-api/src/main/java/com/biengual/userapi/content/domain/ContentLevelFeedbackHistoryCustomRepository.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/domain/ContentLevelFeedbackHistoryCustomRepository.java
@@ -1,0 +1,68 @@
+package com.biengual.userapi.content.domain;
+
+import com.biengual.core.enums.ContentLevel;
+import com.biengual.core.util.TimeRange;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.biengual.core.domain.entity.content.QContentLevelFeedbackHistoryEntity.contentLevelFeedbackHistoryEntity;
+
+@Repository
+@RequiredArgsConstructor
+public class ContentLevelFeedbackHistoryCustomRepository {
+    private final JPAQueryFactory queryFactory;
+
+    // TimeRange 만큼 ContentId별로 ContentLevelFeedback을 집계하기 위한 쿼리
+    public List<ContentInfo.AggregatedLevelFeedback> countContentLevelsGroupByContentIdInTimeRange(TimeRange timeRange) {
+        return queryFactory
+            .select(
+                Projections.constructor(
+                    ContentInfo.AggregatedLevelFeedback.class,
+                    contentLevelFeedbackHistoryEntity.contentId,
+                    this.countByContentLevel(ContentLevel.LOW),
+                    this.countByContentLevel(ContentLevel.MEDIUM),
+                    this.countByContentLevel(ContentLevel.HIGH),
+                    contentLevelFeedbackHistoryEntity.contentLevel.count()
+                )
+            )
+            .from(contentLevelFeedbackHistoryEntity)
+            .where(this.isFeedbackTimeInTimeRange(timeRange))
+            .groupBy(contentLevelFeedbackHistoryEntity.contentId)
+            .fetch();
+    }
+
+    // Internal Method =================================================================================================
+
+    // ContentLevel 마다 집계하기 위한 조건
+    private BooleanExpression isContentLevelEqual(ContentLevel contentLevel) {
+        return contentLevelFeedbackHistoryEntity.contentLevel.eq(contentLevel);
+    }
+
+    // 조건에 따른 집계
+    private NumberExpression<Long> countByBooleanExpression(BooleanExpression expression) {
+        return new CaseBuilder()
+            .when(expression)
+            .then(1)
+            .otherwise(0)
+            .sum()
+            .longValue();
+    }
+
+    // ContentLevel 마다 집계
+    private NumberExpression<Long> countByContentLevel(ContentLevel contentLevel) {
+        return this.countByBooleanExpression(this.isContentLevelEqual(contentLevel));
+    }
+
+    // 대상이 되는 FeedbackTime을 집계하기 위한 조건
+    private BooleanExpression isFeedbackTimeInTimeRange(TimeRange timeRange) {
+        return contentLevelFeedbackHistoryEntity.feedbackTime.goe(timeRange.start())
+            .and(contentLevelFeedbackHistoryEntity.feedbackTime.lt(timeRange.end()));
+    }
+}

--- a/user-api/src/main/java/com/biengual/userapi/metadata/domain/AggregationMetadataRepository.java
+++ b/user-api/src/main/java/com/biengual/userapi/metadata/domain/AggregationMetadataRepository.java
@@ -1,0 +1,15 @@
+package com.biengual.userapi.metadata.domain;
+
+import com.biengual.core.domain.entity.metadata.AggregationMetadataEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * AggregationMetadataEntity Repository 계층의 인터페이스
+ *
+ * @author 문찬욱
+ */
+public interface AggregationMetadataRepository extends JpaRepository<AggregationMetadataEntity, Long> {
+    Optional<AggregationMetadataEntity> findByTableName(String tableName);
+}

--- a/user-api/src/main/java/com/biengual/userapi/metadata/domain/MetadataStore.java
+++ b/user-api/src/main/java/com/biengual/userapi/metadata/domain/MetadataStore.java
@@ -1,0 +1,10 @@
+package com.biengual.userapi.metadata.domain;
+
+/**
+ * Metadata 도메인의 DataProvider 계층의 인터페이스
+ *
+ * @author 문찬욱
+ */
+public interface MetadataStore {
+    void aggregateContentLevelFeedbackHistory();
+}

--- a/user-api/src/main/java/com/biengual/userapi/metadata/infrastructure/MetadataStoreImpl.java
+++ b/user-api/src/main/java/com/biengual/userapi/metadata/infrastructure/MetadataStoreImpl.java
@@ -45,17 +45,11 @@ public class MetadataStoreImpl implements MetadataStore {
 
             // 각 집계된 Content
             for (ContentInfo.AggregatedLevelFeedback aggregatedLevelFeedback : aggregatedLevelFeedbackList) {
-                System.out.println("집계 info 들어옴? " + aggregatedLevelFeedback.contentId());
-
                 if (!contentLevelFeedbackDataMartRepository.existsById(aggregatedLevelFeedback.contentId())) {
                     ContentLevelFeedbackDataMart contentLevelFeedbackDataMart =
                         aggregatedLevelFeedback.toContentLevelFeedbackDataMart();
 
-                    System.out.println("집계 content 들어옴? " + contentLevelFeedbackDataMart.getContentId());
-
-                    ContentLevelFeedbackDataMart save = contentLevelFeedbackDataMartRepository.save(contentLevelFeedbackDataMart);
-
-                    System.out.println("save 거침? " + save.getContentId());
+                    contentLevelFeedbackDataMartRepository.save(contentLevelFeedbackDataMart);
                 } else {
                     contentLevelFeedbackDataMartCustomRepository
                         .updateByAggregatedLevelFeedbackInfo(aggregatedLevelFeedback);

--- a/user-api/src/main/java/com/biengual/userapi/metadata/infrastructure/MetadataStoreImpl.java
+++ b/user-api/src/main/java/com/biengual/userapi/metadata/infrastructure/MetadataStoreImpl.java
@@ -45,11 +45,14 @@ public class MetadataStoreImpl implements MetadataStore {
 
             // 각 집계된 Content
             for (ContentInfo.AggregatedLevelFeedback aggregatedLevelFeedback : aggregatedLevelFeedbackList) {
+                // 처음 집계된 Content
                 if (!contentLevelFeedbackDataMartRepository.existsById(aggregatedLevelFeedback.contentId())) {
                     ContentLevelFeedbackDataMart contentLevelFeedbackDataMart =
                         aggregatedLevelFeedback.toContentLevelFeedbackDataMart();
 
                     contentLevelFeedbackDataMartRepository.save(contentLevelFeedbackDataMart);
+
+                // 집계된 적 있는 Content
                 } else {
                     contentLevelFeedbackDataMartCustomRepository
                         .updateByAggregatedLevelFeedbackInfo(aggregatedLevelFeedback);
@@ -59,6 +62,7 @@ public class MetadataStoreImpl implements MetadataStore {
             aggregateEndTime = timeRange.end();
         }
 
+        // 집계 완료 후, AggregationMetadata의 해당 TableName에 대한 AggregationTime 업데이트
         aggregationMetadata.updateAggregateEndTime(aggregateEndTime);
     }
 

--- a/user-api/src/main/java/com/biengual/userapi/metadata/infrastructure/MetadataStoreImpl.java
+++ b/user-api/src/main/java/com/biengual/userapi/metadata/infrastructure/MetadataStoreImpl.java
@@ -39,7 +39,9 @@ public class MetadataStoreImpl implements MetadataStore {
 
         // TODO: 현재는 순차 처리이고, 추후 개선하여 성능 비교하면 좋을 것 같습니다.
         // 각 집계 기간
-        for (TimeRange timeRange : aggregationPeriodQueue) {
+        while (!aggregationPeriodQueue.isEmpty()) {
+            TimeRange timeRange = aggregationPeriodQueue.poll();
+
             List<ContentInfo.AggregatedLevelFeedback> aggregatedLevelFeedbackList =
                 contentLevelFeedbackHistoryCustomRepository.countContentLevelsGroupByContentIdInTimeRange(timeRange);
 

--- a/user-api/src/main/java/com/biengual/userapi/metadata/infrastructure/MetadataStoreImpl.java
+++ b/user-api/src/main/java/com/biengual/userapi/metadata/infrastructure/MetadataStoreImpl.java
@@ -33,7 +33,7 @@ public class MetadataStoreImpl implements MetadataStore {
         AggregationMetadataEntity aggregationMetadata =
             this.findAggregationMetadata(CONTENT_LEVEL_FEEDBACK_HISTORY_TABLE);
 
-        LocalDateTime aggregateEndTime = aggregationMetadata.getAggregateEndTime();
+        LocalDateTime nextAggTime = aggregationMetadata.getNextAggTime();
 
         Queue<TimeRange> aggregationPeriodQueue = PeriodUtil.getAggregationPeriodQueue(aggregationMetadata);
 
@@ -61,11 +61,11 @@ public class MetadataStoreImpl implements MetadataStore {
                 }
             }
 
-            aggregateEndTime = timeRange.end();
+            nextAggTime = timeRange.end();
         }
 
-        // 집계 완료 후, AggregationMetadata의 해당 TableName에 대한 AggregationTime 업데이트
-        aggregationMetadata.updateAggregateEndTime(aggregateEndTime);
+        // 집계 완료 후, AggregationMetadata의 해당 TableName에 대한 NextAggTime 업데이트
+        aggregationMetadata.updateNextAggTime(nextAggTime);
     }
 
     // Internal Method =================================================================================================

--- a/user-api/src/main/java/com/biengual/userapi/metadata/infrastructure/MetadataStoreImpl.java
+++ b/user-api/src/main/java/com/biengual/userapi/metadata/infrastructure/MetadataStoreImpl.java
@@ -1,0 +1,78 @@
+package com.biengual.userapi.metadata.infrastructure;
+
+import com.biengual.core.annotation.DataProvider;
+import com.biengual.core.domain.entity.content.ContentLevelFeedbackDataMart;
+import com.biengual.core.domain.entity.metadata.AggregationMetadataEntity;
+import com.biengual.core.util.PeriodUtil;
+import com.biengual.core.util.TimeRange;
+import com.biengual.userapi.content.domain.ContentInfo;
+import com.biengual.userapi.content.domain.ContentLevelFeedbackDataMartCustomRepository;
+import com.biengual.userapi.content.domain.ContentLevelFeedbackDataMartRepository;
+import com.biengual.userapi.content.domain.ContentLevelFeedbackHistoryCustomRepository;
+import com.biengual.userapi.metadata.domain.AggregationMetadataRepository;
+import com.biengual.userapi.metadata.domain.MetadataStore;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Queue;
+
+import static com.biengual.core.constant.ServiceConstant.CONTENT_LEVEL_FEEDBACK_HISTORY_TABLE;
+
+@DataProvider
+@RequiredArgsConstructor
+public class MetadataStoreImpl implements MetadataStore {
+    private final AggregationMetadataRepository aggregationMetadataRepository;
+    private final ContentLevelFeedbackHistoryCustomRepository contentLevelFeedbackHistoryCustomRepository;
+    private final ContentLevelFeedbackDataMartRepository contentLevelFeedbackDataMartRepository;
+    private final ContentLevelFeedbackDataMartCustomRepository contentLevelFeedbackDataMartCustomRepository;
+
+    // ContentLevelFeedbackHistory 집계
+    @Override
+    public void aggregateContentLevelFeedbackHistory() {
+        AggregationMetadataEntity aggregationMetadata =
+            this.findAggregationMetadata(CONTENT_LEVEL_FEEDBACK_HISTORY_TABLE);
+
+        LocalDateTime aggregateEndTime = aggregationMetadata.getAggregateEndTime();
+
+        Queue<TimeRange> aggregationPeriodQueue = PeriodUtil.getAggregationPeriodQueue(aggregationMetadata);
+
+        // TODO: 현재는 순차 처리이고, 추후 개선하여 성능 비교하면 좋을 것 같습니다.
+        // 각 집계 기간
+        for (TimeRange timeRange : aggregationPeriodQueue) {
+            List<ContentInfo.AggregatedLevelFeedback> aggregatedLevelFeedbackList =
+                contentLevelFeedbackHistoryCustomRepository
+                    .countContentLevelGroupByContentIdAndContentLevelInTimeRange(timeRange);
+
+            // 각 집계된 Content
+            for (ContentInfo.AggregatedLevelFeedback aggregatedLevelFeedback : aggregatedLevelFeedbackList) {
+                if (!contentLevelFeedbackDataMartRepository.existsById(aggregatedLevelFeedback.contentId())) {
+                    ContentLevelFeedbackDataMart contentLevelFeedbackDataMart =
+                        aggregatedLevelFeedback.toContentLevelFeedbackDataMart();
+
+                    contentLevelFeedbackDataMartRepository.save(contentLevelFeedbackDataMart);
+                } else {
+                    contentLevelFeedbackDataMartCustomRepository
+                        .updateByAggregatedLevelFeedbackInfo(aggregatedLevelFeedback);
+                }
+            }
+
+            aggregateEndTime = timeRange.end();
+        }
+
+        aggregationMetadata.updateAggregateEndTime(aggregateEndTime);
+    }
+
+    // Internal Method =================================================================================================
+
+    // TableName에 맞는 집계 메타데이터를 얻는 메소드
+    private AggregationMetadataEntity findAggregationMetadata(String tableName) {
+        return aggregationMetadataRepository.findByTableName(tableName)
+            .orElseGet(() -> {
+                AggregationMetadataEntity aggregationMetadata =
+                    AggregationMetadataEntity.createEntityByTableName(tableName);
+
+                return aggregationMetadataRepository.save(aggregationMetadata);
+            });
+    }
+}

--- a/user-api/src/main/java/com/biengual/userapi/metadata/infrastructure/MetadataStoreImpl.java
+++ b/user-api/src/main/java/com/biengual/userapi/metadata/infrastructure/MetadataStoreImpl.java
@@ -41,16 +41,21 @@ public class MetadataStoreImpl implements MetadataStore {
         // 각 집계 기간
         for (TimeRange timeRange : aggregationPeriodQueue) {
             List<ContentInfo.AggregatedLevelFeedback> aggregatedLevelFeedbackList =
-                contentLevelFeedbackHistoryCustomRepository
-                    .countContentLevelGroupByContentIdAndContentLevelInTimeRange(timeRange);
+                contentLevelFeedbackHistoryCustomRepository.countContentLevelsGroupByContentIdInTimeRange(timeRange);
 
             // 각 집계된 Content
             for (ContentInfo.AggregatedLevelFeedback aggregatedLevelFeedback : aggregatedLevelFeedbackList) {
+                System.out.println("집계 info 들어옴? " + aggregatedLevelFeedback.contentId());
+
                 if (!contentLevelFeedbackDataMartRepository.existsById(aggregatedLevelFeedback.contentId())) {
                     ContentLevelFeedbackDataMart contentLevelFeedbackDataMart =
                         aggregatedLevelFeedback.toContentLevelFeedbackDataMart();
 
-                    contentLevelFeedbackDataMartRepository.save(contentLevelFeedbackDataMart);
+                    System.out.println("집계 content 들어옴? " + contentLevelFeedbackDataMart.getContentId());
+
+                    ContentLevelFeedbackDataMart save = contentLevelFeedbackDataMartRepository.save(contentLevelFeedbackDataMart);
+
+                    System.out.println("save 거침? " + save.getContentId());
                 } else {
                     contentLevelFeedbackDataMartCustomRepository
                         .updateByAggregatedLevelFeedbackInfo(aggregatedLevelFeedback);

--- a/user-api/src/main/java/com/biengual/userapi/schedule/application/ScheduleServiceImpl.java
+++ b/user-api/src/main/java/com/biengual/userapi/schedule/application/ScheduleServiceImpl.java
@@ -1,20 +1,20 @@
 package com.biengual.userapi.schedule.application;
 
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
+import com.biengual.userapi.metadata.domain.MetadataStore;
 import com.biengual.userapi.mission.domain.MissionStore;
 import com.biengual.userapi.missionhistory.domain.MissionHistoryStore;
 import com.biengual.userapi.schedule.domain.ScheduleService;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class ScheduleServiceImpl implements ScheduleService {
     private final MissionStore missionStore;
     private final MissionHistoryStore missionHistoryStore;
+    private final MetadataStore metadataStore;
 
     /**
      * 미션 리셋 : 04:00 기준
@@ -25,5 +25,14 @@ public class ScheduleServiceImpl implements ScheduleService {
     public void scheduleResetMission() {
         missionHistoryStore.saveMissionsBeforeReset();
         missionStore.resetMission();
+    }
+
+    // TODO: 나중에 같은 시간에 실행하는 집계 관련 스케줄러는
+    //  aggregationMetadata의 모든 데이터를 가져와 한번에 실행할 수 있을 것 같습니다.
+    @Override
+    @Transactional
+    @Scheduled(cron = "00 00 04 * * *")
+    public void aggregateContentLevelFeedback() {
+        metadataStore.aggregateContentLevelFeedbackHistory();
     }
 }

--- a/user-api/src/main/java/com/biengual/userapi/schedule/domain/ScheduleService.java
+++ b/user-api/src/main/java/com/biengual/userapi/schedule/domain/ScheduleService.java
@@ -1,5 +1,13 @@
 package com.biengual.userapi.schedule.domain;
 
+/**
+ * 스케줄링 관련 Service
+ *
+ * @author 김영래
+ */
+
 public interface ScheduleService {
     void scheduleResetMission();
+
+    void aggregateContentLevelFeedback();
 }

--- a/user-api/src/main/resources/db/migration/V1.14.0__alter.sql
+++ b/user-api/src/main/resources/db/migration/V1.14.0__alter.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `content`
+    ADD COLUMN `content_level` ENUM ('LOW', 'MEDIUM', 'HIGH') DEFAULT NULL;

--- a/user-api/src/main/resources/db/migration/V1.14.1__create.sql
+++ b/user-api/src/main/resources/db/migration/V1.14.1__create.sql
@@ -5,9 +5,6 @@ CREATE TABLE IF NOT EXISTS `content_level_feedback_data_mart`
     `level_medium_count`   BIGINT      NOT NULL,
     `level_high_count`     BIGINT      NOT NULL,
     `feedback_total_count` BIGINT      NOT NULL,
-    `aggregation_time`     DATETIME(6) NOT NULL,
-    `created_at`           DATETIME(6) DEFAULT NULL,
-    `updated_at`           DATETIME(6) DEFAULT NULL,
     PRIMARY KEY (`id`)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4

--- a/user-api/src/main/resources/db/migration/V1.14.1__create.sql
+++ b/user-api/src/main/resources/db/migration/V1.14.1__create.sql
@@ -1,11 +1,11 @@
 CREATE TABLE IF NOT EXISTS `content_level_feedback_data_mart`
 (
-    `id`                   BIGINT      NOT NULL,
+    `content_id`                   BIGINT      NOT NULL,
     `level_low_count`      BIGINT      NOT NULL,
     `level_medium_count`   BIGINT      NOT NULL,
     `level_high_count`     BIGINT      NOT NULL,
     `feedback_total_count` BIGINT      NOT NULL,
-    PRIMARY KEY (`id`)
+    PRIMARY KEY (`content_id`)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_0900_ai_ci;

--- a/user-api/src/main/resources/db/migration/V1.14.1__create.sql
+++ b/user-api/src/main/resources/db/migration/V1.14.1__create.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS `content_level_feedback_data_mart`
+(
+    `id`                   BIGINT      NOT NULL,
+    `level_low_count`      BIGINT      NOT NULL,
+    `level_medium_count`   BIGINT      NOT NULL,
+    `level_high_count`     BIGINT      NOT NULL,
+    `feedback_total_count` BIGINT      NOT NULL,
+    `aggregation_time`     DATETIME(6) NOT NULL,
+    `created_at`           DATETIME(6) DEFAULT NULL,
+    `updated_at`           DATETIME(6) DEFAULT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;

--- a/user-api/src/main/resources/db/migration/V1.14.2__create.sql
+++ b/user-api/src/main/resources/db/migration/V1.14.2__create.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS `aggregation_metadata`
     `table_name`         varchar(100)                                         NOT NULL,
     `aggregate_end_time` datetime(6)                                          NOT NULL,
     `interval_type`      enum ('YEARLY', 'MONTHLY', 'DAILY', 'HOURLY', 'ALL') NOT NULL,
-    `interval`           tinyint                                              NOT NULL,
+    `interval_number`    tinyint                                              NOT NULL,
     `created_at`         datetime(6) DEFAULT NULL,
     `updated_at`         datetime(6) DEFAULT NULL,
     PRIMARY KEY (`id`),

--- a/user-api/src/main/resources/db/migration/V1.14.2__create.sql
+++ b/user-api/src/main/resources/db/migration/V1.14.2__create.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS `aggregation_metadata`
     `table_name`         varchar(100)                                         NOT NULL,
     `aggregate_end_time` datetime(6)                                          NOT NULL,
     `interval_type`      enum ('YEARLY', 'MONTHLY', 'DAILY', 'HOURLY', 'ALL') NOT NULL,
-    'interval'           tinyint                                              NOT NULL,
+    `interval`           tinyint                                              NOT NULL,
     `created_at`         datetime(6) DEFAULT NULL,
     `updated_at`         datetime(6) DEFAULT NULL,
     PRIMARY KEY (`id`),

--- a/user-api/src/main/resources/db/migration/V1.14.2__create.sql
+++ b/user-api/src/main/resources/db/migration/V1.14.2__create.sql
@@ -2,7 +2,7 @@ CREATE TABLE IF NOT EXISTS `aggregation_metadata`
 (
     `id`                 bigint                                               NOT NULL AUTO_INCREMENT,
     `table_name`         varchar(100)                                         NOT NULL,
-    `aggregate_end_time` datetime(6)                                          NOT NULL,
+    `next_agg_time` datetime(6)                                          NOT NULL,
     `interval_type`      enum ('YEARLY', 'MONTHLY', 'DAILY', 'HOURLY', 'ALL') NOT NULL,
     `interval_number`    tinyint                                              NOT NULL,
     `created_at`         datetime(6) DEFAULT NULL,

--- a/user-api/src/main/resources/db/migration/V1.14.2__create.sql
+++ b/user-api/src/main/resources/db/migration/V1.14.2__create.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS `aggregation_metadata`
+(
+    `id`                 bigint                                               NOT NULL AUTO_INCREMENT,
+    `table_name`         varchar(100)                                         NOT NULL,
+    `aggregate_end_time` datetime(6)                                          NOT NULL,
+    `interval_type`      enum ('YEARLY', 'MONTHLY', 'DAILY', 'HOURLY', 'ALL') NOT NULL,
+    'interval'           tinyint                                              NOT NULL,
+    `created_at`         datetime(6) DEFAULT NULL,
+    `updated_at`         datetime(6) DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `UKqlsjiwn68bedqaaomcee26hznvxki4` (`table_name`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 9
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;

--- a/user-api/src/main/resources/db/migration/V1.14.2__create.sql
+++ b/user-api/src/main/resources/db/migration/V1.14.2__create.sql
@@ -10,6 +10,5 @@ CREATE TABLE IF NOT EXISTS `aggregation_metadata`
     PRIMARY KEY (`id`),
     UNIQUE KEY `UKqlsjiwn68bedqaaomcee26hznvxki4` (`table_name`)
 ) ENGINE = InnoDB
-  AUTO_INCREMENT = 9
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_0900_ai_ci;

--- a/user-api/src/main/resources/db/migration/V1.14.3__alter.sql
+++ b/user-api/src/main/resources/db/migration/V1.14.3__alter.sql
@@ -1,2 +1,2 @@
 ALTER TABLE `content_level_feedback_history`
-    CHANGE COLUMN `create_at` `feedback_time` DATETIME(6) NOT NULL;
+    CHANGE COLUMN `created_at` `feedback_time` DATETIME(6) NOT NULL;

--- a/user-api/src/main/resources/db/migration/V1.14.3__alter.sql
+++ b/user-api/src/main/resources/db/migration/V1.14.3__alter.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `content_level_feedback_history`
+    CHANGE COLUMN `create_at` `feedback_time` DATETIME(6) NOT NULL;

--- a/user-api/src/main/resources/db/migration/V1.14.4__alter.sql
+++ b/user-api/src/main/resources/db/migration/V1.14.4__alter.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `content_level_feedback_history`
+    DROP COLUMN update_at;

--- a/user-api/src/main/resources/db/migration/V1.14.4__alter.sql
+++ b/user-api/src/main/resources/db/migration/V1.14.4__alter.sql
@@ -1,2 +1,2 @@
 ALTER TABLE `content_level_feedback_history`
-    DROP COLUMN update_at;
+    DROP COLUMN updated_at;


### PR DESCRIPTION
### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 리팩토링
- [ ] 스타일 수정
- [ ] 테스트 코드 추가
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 개발 환경 세팅

### 변경 사항
- 집계 테이블의 메타데이터를 저장하기 위한 AggregationMetadata 엔티티 및 Flyway 버전 추가
- 전체 기간 동안 ContentLevelFeedback에 대한 집계를 보여주기 위한 ContentLevelFeedbackDataMart 엔티티 및 Flyway 버전 추가
- 집계 기능에 맞게 ContentLevelFeedbackHistory 엔티티 수정 및 Flyway 버전 추가
- 집계 기능을 위한 Scheduler, DataProvider, Repository, Info, Util 구현
- Scheduler는 오전 4시에 동작하게 구현


### 참고 사항
- 관련 이슈 번호: #393 
- 집계 로직이 커서 이후 PR에 Content에 집계 결과에 대한 ContentLevel를 반영하고, 컨텐츠 관련 응답 Dto에 ContentLevel을 추가할 예정입니다.
- 집계 로직은 개선 후 성능을 비교해보고자 for문으로 순차 처리하도록 구현했습니다.


### 셀프 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [ ] 새로운 테스트를 추가했거나 기존 테스트를 통과하는지 확인
- [x] 코드 스타일 가이드에 맞게 포맷팅했는지 확인
- [x] 관련 문서를 업데이트했는지 확인
