### PR TITLE
[REFACTOR] 로깅에 찍은 Ip를 최대한 Client IP가 되도록 수정

### DIFF
--- a/biengual-core/src/main/java/com/biengual/core/util/GlobalExceptionLogSchema.java
+++ b/biengual-core/src/main/java/com/biengual/core/util/GlobalExceptionLogSchema.java
@@ -21,19 +21,16 @@ public record GlobalExceptionLogSchema(
     public static GlobalExceptionLogSchema of(
         String server, String user, HttpServletRequest request, ApiCustomResponse response
     ) {
-        Object optionalRequestBody = request.getAttribute("requestBody");
-        boolean existsRequestBody = optionalRequestBody.toString().isEmpty();
-
         return GlobalExceptionLogSchema.builder()
             .server(server)
-            .ip(request.getRemoteAddr())
+            .ip(HttpServletRequestUtil.getClientIp(request))
             .contentType(request.getContentType())
             .userAgent(request.getHeader("User-Agent"))
             .user(user)
             .httpMethod(request.getMethod())
             .uri(request.getRequestURI())
             .params(request.getQueryString())
-            .requestBody(existsRequestBody ? null : optionalRequestBody)
+            .requestBody(HttpServletRequestUtil.getRequestBody(request))
             .code(response.code())
             .message(response.message())
             .build();

--- a/biengual-core/src/main/java/com/biengual/core/util/HttpServletRequestUtil.java
+++ b/biengual-core/src/main/java/com/biengual/core/util/HttpServletRequestUtil.java
@@ -1,0 +1,27 @@
+package com.biengual.core.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public class HttpServletRequestUtil {
+
+    // 로깅에 남길 RequestBody를 얻는 메서드
+    public static Object getRequestBody(HttpServletRequest request) {
+        Object optionalRequestBody = request.getAttribute("requestBody");
+        boolean existsRequestBody = optionalRequestBody.toString().isEmpty();
+
+        return existsRequestBody ? null : optionalRequestBody;
+    }
+
+    // 로깅에 남길 클라이언트 IP를 얻는 메서드
+    public static String getClientIp(HttpServletRequest request) {
+        String ip = request.getHeader("X-Forwarded-For");
+
+        if (ip != null && !ip.isEmpty()) {
+            ip = ip.split(",")[0].trim();
+        } else {
+            ip = request.getRemoteAddr();
+        }
+
+        return ip;
+    }
+}

--- a/biengual-core/src/main/java/com/biengual/core/util/HttpServletRequestUtil.java
+++ b/biengual-core/src/main/java/com/biengual/core/util/HttpServletRequestUtil.java
@@ -14,14 +14,14 @@ public class HttpServletRequestUtil {
 
     // 로깅에 남길 클라이언트 IP를 얻는 메서드
     public static String getClientIp(HttpServletRequest request) {
-        String ip = request.getHeader("X-Forwarded-For");
+        String clientIp = request.getHeader("X-Forwarded-For");
 
-        if (ip != null && !ip.isEmpty()) {
-            ip = ip.split(",")[0].trim();
+        if (clientIp != null && !clientIp.isEmpty()) {
+            clientIp = clientIp.split(",")[0].trim();
         } else {
-            ip = request.getRemoteAddr();
+            clientIp = request.getRemoteAddr();
         }
 
-        return ip;
+        return clientIp;
     }
 }

--- a/biengual-core/src/main/java/com/biengual/core/util/RestControllerSuccessLogSchema.java
+++ b/biengual-core/src/main/java/com/biengual/core/util/RestControllerSuccessLogSchema.java
@@ -22,19 +22,16 @@ public record RestControllerSuccessLogSchema(
     public static RestControllerSuccessLogSchema of(
         String server, String user, Long responseTime, HttpServletRequest request, ApiCustomResponse response
     ) {
-        Object optionalRequestBody = request.getAttribute("requestBody");
-        boolean existsRequestBody = optionalRequestBody.toString().isEmpty();
-
         return RestControllerSuccessLogSchema.builder()
             .server(server)
-            .ip(request.getRemoteAddr())
+            .ip(HttpServletRequestUtil.getClientIp(request))
             .contentType(request.getContentType())
             .userAgent(request.getHeader("User-Agent"))
             .user(user)
             .httpMethod(request.getMethod())
             .uri(request.getRequestURI())
             .params(request.getQueryString())
-            .requestBody(existsRequestBody ? null : optionalRequestBody)
+            .requestBody(HttpServletRequestUtil.getRequestBody(request))
             .code(response.code())
             .message(response.message())
             .responseTime(responseTime)


### PR DESCRIPTION
### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 리팩토링
- [ ] 스타일 수정
- [ ] 테스트 코드 추가
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 개발 환경 세팅

### 변경 사항
- 기존에 RemoteAddr로 바로 직전 요청이 온 IP를 받고 있던걸 X-Forwarded-For 헤더를 이용해 첫 요청 IP를 받는 것으로 수정
- X-Forwarded-For 헤더 없거나 유효하지 않는 경우와 바로 애플리케이션 서버로 요청하는 경우는 원래대로 RemoteAddr를 반환하도록 했습니다.
- 로깅에 남길 RequestBody와 IP를 반환하는 HttpServletRequestUtil 구현


### 참고 사항
- 관련 이슈 번호: #426 


### 셀프 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [ ] 새로운 테스트를 추가했거나 기존 테스트를 통과하는지 확인
- [x] 코드 스타일 가이드에 맞게 포맷팅했는지 확인
- [ ] 관련 문서를 업데이트했는지 확인
