### PR TITLE
[BUGFIX] Question 조회 시 QuestionId 가 null로 오는 버그 해결

### DIFF
--- a/user-api/src/main/java/com/biengual/userapi/question/domain/QuestionDocumentRepository.java
+++ b/user-api/src/main/java/com/biengual/userapi/question/domain/QuestionDocumentRepository.java
@@ -3,11 +3,9 @@ package com.biengual.userapi.question.domain;
 import com.biengual.core.domain.document.question.QuestionDocument;
 import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.data.mongodb.repository.Query;
 
 import java.util.List;
 
 public interface QuestionDocumentRepository extends MongoRepository<QuestionDocument, ObjectId> {
-    @Query("{ '_id' : { $in: ?0 } }")
     List<QuestionInfo.Detail> findByIdIn(List<ObjectId> ids);
 }

--- a/user-api/src/main/java/com/biengual/userapi/question/domain/QuestionInfo.java
+++ b/user-api/src/main/java/com/biengual/userapi/question/domain/QuestionInfo.java
@@ -12,18 +12,10 @@ public class QuestionInfo {
     @Builder
     public record Detail(
         String question,
-        String questionId,
+        String id,
         List<String> examples,
         QuestionType type
     ) {
-        public static Detail of(QuestionDocument questionDocument) {
-            return QuestionInfo.Detail.builder()
-                .question(questionDocument.getQuestion())
-                .questionId(questionDocument.getId().toString())
-                .examples(questionDocument.getExamples())
-                .type(questionDocument.getType())
-                .build();
-        }
     }
 
     @Builder

--- a/user-api/src/main/java/com/biengual/userapi/question/presentation/QuestionDtoMapper.java
+++ b/user-api/src/main/java/com/biengual/userapi/question/presentation/QuestionDtoMapper.java
@@ -37,6 +37,9 @@ public interface QuestionDtoMapper {
     // Response <- Info
     QuestionResponseDto.ViewListRes ofViewListRes(QuestionInfo.DetailInfo info);
 
+    @Mapping(target = "questionId", source = "id")
+    QuestionResponseDto.View ofView(QuestionInfo.Detail info);
+
     GetHintDto.Response ofGetHintRes(QuestionInfo.Hint info);
 
     // Entity <-> Info, Info <-> Info


### PR DESCRIPTION
### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 리팩토링
- [ ] 스타일 수정
- [ ] 테스트 코드 추가
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 개발 환경 세팅

### 변경 사항
- Projection 대상 클래스인 QuestionInfo.Detail의 멤버 변수 questionId를 id로 변경함으로써 매핑이 되도록 수정
- QuestionInfo.Detail의 변경됨에 따라 관련 로직 수정


### 참고 사항
- 관련 이슈 번호: #457 
- Question Document 의 id는 Projection 대상 클래스인 QuestionInfo.Detail의 멤버 변수에 동일한 이름인 id가 존재하지 않기 때문에 매핑이 되지 않아서 QuestionInfo.Detail의 questionId가 null이 되어서 발생한 버그입니다.
- QueryDsl 없이 Spring Data MongoDB만 의존성을 추가했을 경우 Projection 하는 방법은 3가지가 있었습니다.
- 1. 지금처럼 Projection 대상 클래스의 멤버 변수를 Document 필드 이름과 동일하게 구성
- 2. Spring Data MongoDB 기능인 Projection Interface 생성
- 3. MongoDB Converter 구현
- 저는 MapStruct를 사용하고 있고, 현재 Info 구조에 1. 이 가장 낫다고 판단하여 1. 으로 해결했습니다.


### 셀프 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [ ] 새로운 테스트를 추가했거나 기존 테스트를 통과하는지 확인
- [x] 코드 스타일 가이드에 맞게 포맷팅했는지 확인
- [ ] 관련 문서를 업데이트했는지 확인
