### PR TITLE
[BUGFIX] 카테고리 기반 컨텐츠 추천 기능 에러 해결

### DIFF
--- a/biengual-core/src/main/java/com/biengual/core/util/StringListConverter.java
+++ b/biengual-core/src/main/java/com/biengual/core/util/StringListConverter.java
@@ -1,5 +1,6 @@
 package com.biengual.core.util;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -17,6 +18,10 @@ public class StringListConverter implements AttributeConverter<List<String>, Str
 
     @Override
     public List<String> convertToEntityAttribute(String dbData) {
+        if (dbData.isEmpty()) {
+            return new ArrayList<>();
+        }
+
         return Arrays.asList(dbData.split(DELIMITER));
     }
 }

--- a/user-api/src/main/java/com/biengual/userapi/content/domain/ContentCustomRepository.java
+++ b/user-api/src/main/java/com/biengual/userapi/content/domain/ContentCustomRepository.java
@@ -264,6 +264,27 @@ public class ContentCustomRepository {
         return previews;
     }
 
+    // 추천 카테고리가 하나도 없을 때 조회수 순으로 9개 조회
+    public List<RecommenderInfo.Preview> findContentsOrderByHits(Long userId) {
+        return queryFactory
+            .select(
+                Projections.constructor(
+                    RecommenderInfo.Preview.class,
+                    contentEntity.id,
+                    contentEntity.title,
+                    contentEntity.thumbnailUrl,
+                    contentEntity.contentType,
+                    contentEntity.category.name,
+                    contentEntity.contentLevel,
+                    getIsPointRequiredByUserIdAndContent(userId, contentEntity.id, contentEntity.createdAt)
+                )
+            )
+            .from(contentEntity)
+            .orderBy(contentEntity.hits.desc())
+            .limit(9)
+            .fetch();
+    }
+
     // Internal Method =================================================================================================
 
     // TODO: Predicate를 사용하지 않는 경우에는 Override? 아니면 null로 입력?

--- a/user-api/src/main/java/com/biengual/userapi/learning/infrastructure/LearningReaderImpl.java
+++ b/user-api/src/main/java/com/biengual/userapi/learning/infrastructure/LearningReaderImpl.java
@@ -1,9 +1,6 @@
 package com.biengual.userapi.learning.infrastructure;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import com.biengual.core.annotation.DataProvider;
 import com.biengual.userapi.content.domain.ContentCustomRepository;
@@ -23,6 +20,7 @@ public class LearningReaderImpl implements LearningReader {
     private final ContentCustomRepository contentCustomRepository;
     private final RecommenderCustomRepository recommenderCustomRepository;
 
+    // TODO: 카테고리 기반 추천 알고리즘 로직 개선할 것
     @Override
     public RecommenderInfo.PreviewRecommender findSimilarCategoriesBasedOnLearningHistory(Long userId) {
         // 1. 유저의 관심 높은 카테고리 찾기(관심 카테고리, 최근 많이 학습한 카테고리)
@@ -41,7 +39,14 @@ public class LearningReaderImpl implements LearningReader {
         // 3. 위 카테고리를 학습한 유저들의 다른 카테고리 리턴(나는 많이 학습하지 않은)
         List<Long> similarCategories = recommenderCustomRepository.findSimilarCategories(interestedCategoryIds);
 
-        // 4. 각 카테고리 ID 당 조회수, 스크랩수 기준으로 상위 컨텐츠 리턴
+        // 4.유사 카테고리들이 없는 경우 조회수 순으로 컨텐츠 반환
+        if (similarCategories.isEmpty()) {
+            return RecommenderInfo.PreviewRecommender.of(
+                contentCustomRepository.findContentsOrderByHits(userId)
+            );
+        }
+
+        // 5. 각 카테고리 ID 당 조회수, 스크랩수 기준으로 상위 컨텐츠 리턴
         return RecommenderInfo.PreviewRecommender.of(
             contentCustomRepository.findCustomizedContentsByCategories(userId, similarCategories)
         );

--- a/user-api/src/main/java/com/biengual/userapi/recommender/domain/RecommenderCustomRepository.java
+++ b/user-api/src/main/java/com/biengual/userapi/recommender/domain/RecommenderCustomRepository.java
@@ -94,7 +94,13 @@ public class RecommenderCustomRepository {
 
         // 각 categoryId에 대해 similarCategoryIds 중 첫 번째로 categoryId와 다른 값을 선택
         for (Long categoryId : categoryIds) {
-            similarCategoryIdsList.get(categoryIds.indexOf(categoryId))
+            List<String> similarCategoryIds = similarCategoryIdsList.get(categoryIds.indexOf(categoryId));
+
+            if (similarCategoryIds.isEmpty()) {
+                continue;
+            }
+
+            similarCategoryIds
                 .stream()
                 .map(Long::valueOf)  // String -> Long 변환
                 .filter(similarId -> !categoryIds.contains(similarId))  // categoryId와 다른 값 선택
@@ -125,8 +131,8 @@ public class RecommenderCustomRepository {
 
         // Set을 List로 변환하고 정확히 3개의 결과만 반환
         return uniqueSimilarCategoryIds.stream()
-            .limit(3)  // 정확히 3개만 반환
-            .collect(Collectors.toList());
+            .limit(Math.min(uniqueSimilarCategoryIds.size(), 3))  // 정확히 3개만 반환
+            .toList();
     }
 
     // 유저가 처음 회원 가입을 해서 카테고리 관련 유저 정보가 없을 때 단순히 랜덤 카테고리를 가져오기 위한 쿼리


### PR DESCRIPTION
### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 리팩토링
- [ ] 스타일 수정
- [ ] 테스트 코드 추가
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 개발 환경 세팅

### 변경 사항
- category_recommender에서 similar_category_ids가 "" 인 경우에 대한 convert 처리 추가
- 추천할 카테고리가 하나도 없는 경우에 대한 로직 추가


### 참고 사항
- 관련 이슈 번호: #469 
- category_recommender에서 similar_category_ids가 "" 인 경우에 QueryDsl에서 가져올 때 ""로 가져와서 `For input string: ""` 에러가 발생합니다.
- 위의 버그와 관련해서 where 문에서 categoryRecommenderEntity.similarCategoryIds 가 빈리스트가 아닌경우로 해결하려 했으나, 제가 판단하기론 QueryDsl은 ""을 빈리스트로 인식했지만, 하버네이트는 ""으로 인식해서 매핑이 안되는 문제가 발생합니다.
- 추천할 카테고리가 하나도 없는 경우에 index 관련 에러가 발생합니다.


### 셀프 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [ ] 새로운 테스트를 추가했거나 기존 테스트를 통과하는지 확인
- [x] 코드 스타일 가이드에 맞게 포맷팅했는지 확인
- [ ] 관련 문서를 업데이트했는지 확인
