### PR TITLE
[HOTFIX] getImage method 의 URI 리턴에서 "https://" 삭제

### DIFF
--- a/user-api/src/main/java/com/biengual/userapi/image/infrastructure/ImageReaderImpl.java
+++ b/user-api/src/main/java/com/biengual/userapi/image/infrastructure/ImageReaderImpl.java
@@ -35,7 +35,7 @@ public class ImageReaderImpl implements ImageReader {
             return s3Client.utilities().getUrl(getUrlRequest).toString();
         }
 
-        return URI.create("https://" + cloudfrontDomain).resolve(key).toString();
+        return URI.create(cloudfrontDomain).resolve(key).toString();
     }
 
     // Internal Methods ================================================================================================


### PR DESCRIPTION
### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 리팩토링
- [ ] 스타일 수정
- [ ] 테스트 코드 추가
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 개발 환경 세팅

### 변경 사항
- getImage method 의 URI 리턴에서 "https://" 삭제

### 셀프 체크리스트
- [ ] 코드가 정상적으로 동작하는지 확인
- [ ] 새로운 테스트를 추가했거나 기존 테스트를 통과하는지 확인
- [ ] 코드 스타일 가이드에 맞게 포맷팅했는지 확인
- [ ] 관련 문서를 업데이트했는지 확인
