### PR TITLE
[FEAT] 프론트 요청으로 인한 Server Timing API를 위한 Filter 추가

### DIFF
--- a/user-api/src/main/java/com/biengual/userapi/config/HttpRequestFilterConfig.java
+++ b/user-api/src/main/java/com/biengual/userapi/config/HttpRequestFilterConfig.java
@@ -1,9 +1,11 @@
 package com.biengual.userapi.config;
 
 import com.biengual.userapi.filter.ReadableRequestWrapperFilter;
+import com.biengual.userapi.filter.ServerTimingFilter;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 @Configuration
 public class HttpRequestFilterConfig {
@@ -14,6 +16,17 @@ public class HttpRequestFilterConfig {
         registrationBean.setFilter(new ReadableRequestWrapperFilter());
         registrationBean.addUrlPatterns("/*");
         registrationBean.setName("readableRequestWrapperFilter");
+        return registrationBean;
+    }
+
+    @Bean
+    @Profile({"local", "dev"})
+    public FilterRegistrationBean<ServerTimingFilter> serverTimingFilter() {
+        FilterRegistrationBean<ServerTimingFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(new ServerTimingFilter());
+        registrationBean.addUrlPatterns("/*");
+        registrationBean.setName("serverTimingFilter");
+        registrationBean.setOrder(1);
         return registrationBean;
     }
 }

--- a/user-api/src/main/java/com/biengual/userapi/filter/ServerTimingFilter.java
+++ b/user-api/src/main/java/com/biengual/userapi/filter/ServerTimingFilter.java
@@ -1,0 +1,28 @@
+package com.biengual.userapi.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.io.IOException;
+
+@Profile({"local", "dev"})
+public class ServerTimingFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+        throws ServletException, IOException {
+        long startTime = System.currentTimeMillis();
+        try {
+            ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(response);
+            filterChain.doFilter(request, responseWrapper);
+        } finally {
+            long duration = System.currentTimeMillis() - startTime;
+            response.addHeader("Server-Timing", String.format("app;dur=%d", duration));
+        }
+    }
+}


### PR DESCRIPTION
### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 리팩토링
- [ ] 스타일 수정
- [ ] 테스트 코드 추가
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 개발 환경 세팅

### 변경 사항
- OncePerRequestFilter 를 extends 한 ServerTimingFilter 구현
- 기존 HttpRequestFilterConfig에서 필터 등록
- 해당 필터는 local과 dev에서 작동하도록 설정


### 참고 사항
- 관련 이슈 번호: #488 
- ContentCachingResponseWrapper를 사용한 이유는 response가 commit 되기 전에만 수정이 가능하기 때문에 commit 되는 시점을 늦추기 위해서 사용했습니다.


### 셀프 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [ ] 새로운 테스트를 추가했거나 기존 테스트를 통과하는지 확인
- [ ] 코드 스타일 가이드에 맞게 포맷팅했는지 확인
- [ ] 관련 문서를 업데이트했는지 확인
