### PR TITLE
[HOTFIX] rss 에서 유튜브 컨텐츠 업데이트 url 받을 시 예외 처리 추가

### DIFF
--- a/user-api/src/main/java/com/biengual/userapi/crawling/infrastructure/CrawlingReaderImpl.java
+++ b/user-api/src/main/java/com/biengual/userapi/crawling/infrastructure/CrawlingReaderImpl.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import java.net.URL;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -29,7 +30,9 @@ import com.rometools.rome.io.SyndFeedInput;
 import com.rometools.rome.io.XmlReader;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @DataProvider
 @RequiredArgsConstructor
 public class CrawlingReaderImpl implements CrawlingReader {
@@ -64,11 +67,16 @@ public class CrawlingReaderImpl implements CrawlingReader {
 
         // 1-2. Youtube 채널 동영상 링크
         // 채널 별로 매일 1개 씩 크롤링
+        List<String> channelIds = Arrays.asList(IDOFTEDED, IDOFVOX, IDOFLIVENOGGIN, IDOFSCISHOW);
         List<String> tempUrls = new ArrayList<>();
-        tempUrls.add(this.getVideoUrls(IDOFTEDED));
-        tempUrls.add(this.getVideoUrls(IDOFVOX));
-        tempUrls.add(this.getVideoUrls(IDOFLIVENOGGIN));
-        tempUrls.add(this.getVideoUrls(IDOFSCISHOW));
+
+        for (String channelId : channelIds) {
+            try {
+                tempUrls.add(this.getVideoUrls(channelId));
+            } catch (Exception e) {
+                log.info("Channel Id : {} 에 대해 업데이트 할 컨텐츠 없음", channelId);
+            }
+        }
 
         commands.addAll(
             tempUrls.stream()


### PR DESCRIPTION
### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 리팩토링
- [ ] 스타일 수정
- [ ] 테스트 코드 추가
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 개발 환경 세팅

### 변경 사항
- rss 에서 유튜브 컨텐츠 업데이트 url 받을 시 예외 처리 추가
- 기존 로직에서 예외를 catch 하지 않아서 유튜브 rss 에서 업데이트할 컨텐츠가 없으면 크롤링 작업 자체가 멈추게 되어 있어서 이를 catch 하는 로직 추가함


### 셀프 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [ ] 새로운 테스트를 추가했거나 기존 테스트를 통과하는지 확인
- [x] 코드 스타일 가이드에 맞게 포맷팅했는지 확인
- [ ] 관련 문서를 업데이트했는지 확인
